### PR TITLE
[Feature] Custom resource controller actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
-- Can now register routes for custom actions on a resource, using the `actions()` helper method when registering
-  resources.
+- [#12](https://github.com/laravel-json-api/laravel/pull/12) Can now register routes for custom actions on a resource,
+  using the `actions()` helper method when registering resources. See the PR for examples.
 - The `JsonApiController` now has the Laravel `AuthorizesRequests`, `DispatchesJobs` and `ValidatesRequests` traits
   applied.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- Can now register routes for custom actions on a resource, using the `actions()` helper method when registering
+  resources.
 - The `JsonApiController` now has the Laravel `AuthorizesRequests`, `DispatchesJobs` and `ValidatesRequests` traits
   applied.
 

--- a/src/Routing/ActionProxy.php
+++ b/src/Routing/ActionProxy.php
@@ -1,0 +1,93 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Laravel\Routing;
+
+use Illuminate\Routing\Route as IlluminateRoute;
+use Illuminate\Support\Traits\ForwardsCalls;
+
+/**
+ * Class ActionProxy
+ *
+ * @mixin IlluminateRoute
+ */
+class ActionProxy
+{
+
+    use ForwardsCalls;
+
+    /**
+     * @var IlluminateRoute
+     */
+    private IlluminateRoute $route;
+
+    /**
+     * @var string
+     */
+    private string $controllerMethod;
+
+    /**
+     * @var bool
+     */
+    private bool $named = false;
+
+    /**
+     * ActionProxy constructor.
+     *
+     * @param IlluminateRoute $route
+     * @param string $controllerMethod
+     */
+    public function __construct(IlluminateRoute $route, string $controllerMethod)
+    {
+        $this->route = $route;
+        $this->controllerMethod = $controllerMethod;
+    }
+
+    /**
+     * @param $name
+     * @param $arguments
+     */
+    public function __call($name, $arguments)
+    {
+        $this->forwardCallTo($this->route, $name, $arguments);
+    }
+
+    /**
+     * @return void
+     */
+    public function __destruct()
+    {
+        if (false === $this->named) {
+            $this->route->name($this->controllerMethod);
+        }
+    }
+
+    /**
+     * @param string $name
+     * @return $this
+     */
+    public function name(string $name): self
+    {
+        $this->route->name($name);
+        $this->named = true;
+
+        return $this;
+    }
+
+}

--- a/src/Routing/ActionRegistrar.php
+++ b/src/Routing/ActionRegistrar.php
@@ -76,7 +76,7 @@ class ActionRegistrar
      * @param string $resourceType
      * @param array $options
      * @param string $controller
-     * @param string $prefix
+     * @param string|null $prefix
      */
     public function __construct(
         RegistrarContract $router,
@@ -85,7 +85,7 @@ class ActionRegistrar
         string $resourceType,
         array $options,
         string $controller,
-        string $prefix
+        string $prefix = null
     ) {
         $this->router = $router;
         $this->resource = $resource;
@@ -108,18 +108,91 @@ class ActionRegistrar
     }
 
     /**
+     * Register a new GET route.
+     *
+     * @param string $uri
+     * @param string|null $method
+     * @return IlluminateRoute
+     */
+    public function get(string $uri, string $method = null): IlluminateRoute
+    {
+        return $this->register('get', $uri, $method);
+    }
+
+    /**
+     * Register a new POST route.
+     *
      * @param string $uri
      * @param string|null $method
      * @return IlluminateRoute
      */
     public function post(string $uri, string $method = null): IlluminateRoute
     {
-        $method = $method ?: $this->guessMethod($uri);
+        return $this->register('post', $uri, $method);
+    }
+
+    /**
+     * Register a new PATCH route.
+     *
+     * @param string $uri
+     * @param string|null $method
+     * @return IlluminateRoute
+     */
+    public function patch(string $uri, string $method = null): IlluminateRoute
+    {
+        return $this->register('patch', $uri, $method);
+    }
+
+    /**
+     * Register a new PUT route.
+     *
+     * @param string $uri
+     * @param string|null $method
+     * @return IlluminateRoute
+     */
+    public function put(string $uri, string $method = null): IlluminateRoute
+    {
+        return $this->register('put', $uri, $method);
+    }
+
+    /**
+     * Register a new DELETE route.
+     *
+     * @param string $uri
+     * @param string|null $method
+     * @return IlluminateRoute
+     */
+    public function delete(string $uri, string $method = null): IlluminateRoute
+    {
+        return $this->register('delete', $uri, $method);
+    }
+
+    /**
+     * Register a new OPTIONS route.
+     *
+     * @param string $uri
+     * @param string|null $method
+     * @return IlluminateRoute
+     */
+    public function options(string $uri, string $method = null): IlluminateRoute
+    {
+        return $this->register('options', $uri, $method);
+    }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @param string|null $action
+     * @return IlluminateRoute
+     */
+    public function register(string $method, string $uri, string $action = null): IlluminateRoute
+    {
+        $action = $action ?: $this->guessControllerAction($uri);
         $parameter = $this->getParameter();
 
-        $route = $this->router->post(
+        $route = $this->router->{$method}(
             $this->uri($uri, $parameter),
-            sprintf('%s@%s', $this->controller, $method)
+            sprintf('%s@%s', $this->controller, $action)
         );
 
         $this->route($route, $parameter);
@@ -191,7 +264,7 @@ class ActionRegistrar
      * @param string $uri
      * @return string
      */
-    private function guessMethod(string $uri): string
+    private function guessControllerAction(string $uri): string
     {
         return Str::camel($uri);
     }

--- a/src/Routing/ActionRegistrar.php
+++ b/src/Routing/ActionRegistrar.php
@@ -1,0 +1,198 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Laravel\Routing;
+
+use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
+use Illuminate\Routing\Route as IlluminateRoute;
+use Illuminate\Routing\RouteCollection;
+use LaravelJsonApi\Core\Support\Str;
+
+class ActionRegistrar
+{
+
+    /**
+     * @var RegistrarContract
+     */
+    private RegistrarContract $router;
+
+    /**
+     * @var ResourceRegistrar
+     */
+    private ResourceRegistrar $resource;
+
+    /**
+     * @var RouteCollection
+     */
+    private RouteCollection $routes;
+
+    /**
+     * @var string
+     */
+    private string $resourceType;
+
+    /**
+     * @var array
+     */
+    private array $options;
+
+    /**
+     * @var string
+     */
+    private string $controller;
+
+    /**
+     * @var string|null
+     */
+    private ?string $prefix;
+
+    /**
+     * @var bool
+     */
+    private bool $id = false;
+
+    /**
+     * ActionRegistrar constructor.
+     *
+     * @param RegistrarContract $router
+     * @param ResourceRegistrar $resource
+     * @param RouteCollection $routes
+     * @param string $resourceType
+     * @param array $options
+     * @param string $controller
+     * @param string $prefix
+     */
+    public function __construct(
+        RegistrarContract $router,
+        ResourceRegistrar $resource,
+        RouteCollection $routes,
+        string $resourceType,
+        array $options,
+        string $controller,
+        string $prefix
+    ) {
+        $this->router = $router;
+        $this->resource = $resource;
+        $this->routes = $routes;
+        $this->resourceType = $resourceType;
+        $this->options = $options;
+        $this->controller = $controller;
+        $this->prefix = $prefix;
+    }
+
+    /**
+     * @return $this
+     */
+    public function withId(): self
+    {
+        $copy = clone $this;
+        $copy->id = true;
+
+        return $copy;
+    }
+
+    /**
+     * @param string $uri
+     * @param string|null $method
+     * @return IlluminateRoute
+     */
+    public function post(string $uri, string $method = null): IlluminateRoute
+    {
+        $method = $method ?: $this->guessMethod($uri);
+        $parameter = $this->getParameter();
+
+        $route = $this->router->post(
+            $this->uri($uri, $parameter),
+            sprintf('%s@%s', $this->controller, $method)
+        );
+
+        $this->route($route, $parameter);
+
+        return $route;
+    }
+
+    /**
+     * @return string|null
+     */
+    private function getParameter(): ?string
+    {
+        if ($this->id) {
+            return $this->resource->getResourceParameterName(
+                $this->resourceType,
+                $this->options
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Configure the supplied route.
+     *
+     * @param IlluminateRoute $route
+     * @param string|null $parameter
+     */
+    private function route(IlluminateRoute $route, ?string $parameter): void
+    {
+        $route->where($this->resource->getWheres(
+            $this->resourceType,
+            $parameter,
+            $this->options
+        ));
+
+        $route->defaults(Route::RESOURCE_TYPE, $this->resourceType);
+
+        if ($parameter) {
+            $route->defaults(Route::RESOURCE_ID_NAME, $parameter);
+        }
+
+        $this->routes->add($route);
+    }
+
+    /**
+     * Normalize the URI.
+     *
+     * @param string $uri
+     * @param string|null $parameter
+     * @return string
+     */
+    private function uri(string $uri, ?string $parameter): string
+    {
+        $uri = ltrim($uri, '/');
+
+        if ($this->prefix) {
+            $uri = sprintf('%s/%s', $this->prefix, $uri);
+        }
+
+        if ($this->id) {
+            return sprintf('{%s}/%s', $parameter, $uri);
+        }
+
+        return $uri;
+    }
+
+    /**
+     * @param string $uri
+     * @return string
+     */
+    private function guessMethod(string $uri): string
+    {
+        return Str::camel($uri);
+    }
+}

--- a/src/Routing/ActionRegistrar.php
+++ b/src/Routing/ActionRegistrar.php
@@ -112,9 +112,9 @@ class ActionRegistrar
      *
      * @param string $uri
      * @param string|null $method
-     * @return IlluminateRoute
+     * @return ActionProxy
      */
-    public function get(string $uri, string $method = null): IlluminateRoute
+    public function get(string $uri, string $method = null): ActionProxy
     {
         return $this->register('get', $uri, $method);
     }
@@ -124,9 +124,9 @@ class ActionRegistrar
      *
      * @param string $uri
      * @param string|null $method
-     * @return IlluminateRoute
+     * @return ActionProxy
      */
-    public function post(string $uri, string $method = null): IlluminateRoute
+    public function post(string $uri, string $method = null): ActionProxy
     {
         return $this->register('post', $uri, $method);
     }
@@ -136,9 +136,9 @@ class ActionRegistrar
      *
      * @param string $uri
      * @param string|null $method
-     * @return IlluminateRoute
+     * @return ActionProxy
      */
-    public function patch(string $uri, string $method = null): IlluminateRoute
+    public function patch(string $uri, string $method = null): ActionProxy
     {
         return $this->register('patch', $uri, $method);
     }
@@ -148,9 +148,9 @@ class ActionRegistrar
      *
      * @param string $uri
      * @param string|null $method
-     * @return IlluminateRoute
+     * @return ActionProxy
      */
-    public function put(string $uri, string $method = null): IlluminateRoute
+    public function put(string $uri, string $method = null): ActionProxy
     {
         return $this->register('put', $uri, $method);
     }
@@ -160,9 +160,9 @@ class ActionRegistrar
      *
      * @param string $uri
      * @param string|null $method
-     * @return IlluminateRoute
+     * @return ActionProxy
      */
-    public function delete(string $uri, string $method = null): IlluminateRoute
+    public function delete(string $uri, string $method = null): ActionProxy
     {
         return $this->register('delete', $uri, $method);
     }
@@ -172,9 +172,9 @@ class ActionRegistrar
      *
      * @param string $uri
      * @param string|null $method
-     * @return IlluminateRoute
+     * @return ActionProxy
      */
-    public function options(string $uri, string $method = null): IlluminateRoute
+    public function options(string $uri, string $method = null): ActionProxy
     {
         return $this->register('options', $uri, $method);
     }
@@ -183,9 +183,9 @@ class ActionRegistrar
      * @param string $method
      * @param string $uri
      * @param string|null $action
-     * @return IlluminateRoute
+     * @return ActionProxy
      */
-    public function register(string $method, string $uri, string $action = null): IlluminateRoute
+    public function register(string $method, string $uri, string $action = null): ActionProxy
     {
         $action = $action ?: $this->guessControllerAction($uri);
         $parameter = $this->getParameter();
@@ -197,7 +197,7 @@ class ActionRegistrar
 
         $this->route($route, $parameter);
 
-        return $route;
+        return new ActionProxy($route, $action);
     }
 
     /**

--- a/src/Routing/ResourceRegistrar.php
+++ b/src/Routing/ResourceRegistrar.php
@@ -110,6 +110,43 @@ class ResourceRegistrar
     }
 
     /**
+     * Register resource custom actions.
+     *
+     * @param string $resourceType
+     * @param string $controller
+     * @param array $options
+     * @param string|null $prefix
+     * @param Closure $callback
+     * @return RouteCollection
+     */
+    public function actions(
+        string $resourceType,
+        string $controller,
+        array $options,
+        ?string $prefix,
+        Closure $callback
+    ): RouteCollection
+    {
+        $attributes = $this->getCustomActions($resourceType, $options);
+
+        $actions = new ActionRegistrar(
+            $this->router,
+            $this,
+            $routes = new RouteCollection(),
+            $resourceType,
+            $options,
+            $controller,
+            $prefix
+        );
+
+        $this->router->group($attributes, function () use ($actions, $callback) {
+            $callback($actions);
+        });
+
+        return $routes;
+    }
+
+    /**
      * Register resource routes.
      *
      * @param string $resourceType
@@ -128,6 +165,47 @@ class ResourceRegistrar
         }
 
         return $routes;
+    }
+
+    /**
+     * @param string $resourceType
+     * @param array $options
+     * @return string
+     */
+    public function getResourceParameterName(string $resourceType, array $options): string
+    {
+        if (isset($options['parameter'])) {
+            return $options['parameter'];
+        }
+
+        $param = Str::singular($resourceType);
+
+        /**
+         * Dash-case is not allowed for route parameters. Therefore if the
+         * resource type contains a dash, we will underscore it.
+         */
+        if (Str::contains($param, '-')) {
+            $param = Str::underscore($param);
+        }
+
+        return $param;
+    }
+
+    /**
+     * @param string $resourceType
+     * @param string|null $parameter
+     * @param array $options
+     * @return array
+     */
+    public function getWheres(string $resourceType, ?string $parameter, array $options): array
+    {
+        $where = $options['wheres'] ?? [];
+
+        if ($parameter && !isset($action['where'][$parameter])) {
+            $where[$parameter] = $this->getIdPattern($resourceType);
+        }
+
+        return $where;
     }
 
     /**
@@ -244,30 +322,6 @@ class ResourceRegistrar
     }
 
     /**
-     * @param string $resourceType
-     * @param array $options
-     * @return string
-     */
-    private function getResourceParameterName(string $resourceType, array $options): string
-    {
-        if (isset($options['parameter'])) {
-            return $options['parameter'];
-        }
-
-        $param = Str::singular($resourceType);
-
-        /**
-         * Dash-case is not allowed for route parameters. Therefore if the
-         * resource type contains a dash, we will underscore it.
-         */
-        if (Str::contains($param, '-')) {
-            $param = Str::underscore($param);
-        }
-
-        return $param;
-    }
-
-    /**
      * Get the action array for a resource route.
      *
      * @param string $resourceType
@@ -332,27 +386,35 @@ class ResourceRegistrar
     }
 
     /**
+     * Get the action array for custom the actions group.
+     *
      * @param string $resourceType
-     * @param string|null $parameter
      * @param array $options
      * @return array
      */
-    private function getWheres(string $resourceType, ?string $parameter, array $options): array
+    private function getCustomActions(string $resourceType, array $options)
     {
-        $where = $options['wheres'] ?? [];
+        $action = [
+            'prefix' => $this->getResourceUri($resourceType),
+            'as' => "{$resourceType}.",
+        ];
 
-        if ($parameter && !isset($action['where'][$parameter])) {
-            $where[$parameter] = $this->getIdPattern($resourceType);
+        if (isset($options['middleware'])) {
+            $action['middleware'] = $options['middleware'];
         }
 
-        return $where;
+        if (isset($options['excluded_middleware'])) {
+            $action['excluded_middleware'] = $options['excluded_middleware'];
+        }
+
+        return $action;
     }
 
     /**
      * @param string $resourceType
      * @return string
      */
-    private function getIdPattern(string $resourceType): string
+    public function getIdPattern(string $resourceType): string
     {
         return $this->server
             ->schemas()

--- a/src/Routing/ResourceRegistrar.php
+++ b/src/Routing/ResourceRegistrar.php
@@ -414,7 +414,7 @@ class ResourceRegistrar
      * @param string $resourceType
      * @return string
      */
-    public function getIdPattern(string $resourceType): string
+    private function getIdPattern(string $resourceType): string
     {
         return $this->server
             ->schemas()

--- a/tests/dummy/app/Http/Controllers/Api/V1/PostController.php
+++ b/tests/dummy/app/Http/Controllers/Api/V1/PostController.php
@@ -22,6 +22,8 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\JsonApi\V1\Posts\PostQuery;
 use App\Models\Post;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Http\Response;
 use LaravelJsonApi\Contracts\Store\Store;
 use LaravelJsonApi\Core\Responses\DataResponse;
 use LaravelJsonApi\Laravel\Http\Controllers\Actions;
@@ -41,14 +43,27 @@ class PostController extends Controller
     use Actions\DetachRelationship;
 
     /**
+     * @return Response
+     * @throws \Illuminate\Auth\Access\AuthorizationException
+     */
+    public function purge(): Response
+    {
+        $this->authorize('deleteAll', Post::class);
+
+        Post::query()->delete();
+
+        return response('', 204);
+    }
+
+    /**
      * Publish a post.
      *
      * @param Store $store
      * @param PostQuery $query
      * @param Post $post
-     * @return DataResponse
+     * @return Responsable
      */
-    public function publish(Store $store, PostQuery $query, Post $post)
+    public function publish(Store $store, PostQuery $query, Post $post): Responsable
     {
         $post->update(['published_at' => now()]);
 
@@ -57,6 +72,6 @@ class PostController extends Controller
             ->using($query)
             ->first();
 
-        return new DataResponse($post);
+        return new DataResponse($model);
     }
 }

--- a/tests/dummy/app/Http/Controllers/Api/V1/PostController.php
+++ b/tests/dummy/app/Http/Controllers/Api/V1/PostController.php
@@ -19,9 +19,14 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Api\V1;
 
+use App\Http\Controllers\Controller;
+use App\JsonApi\V1\Posts\PostQuery;
+use App\Models\Post;
+use LaravelJsonApi\Contracts\Store\Store;
+use LaravelJsonApi\Core\Responses\DataResponse;
 use LaravelJsonApi\Laravel\Http\Controllers\Actions;
 
-class PostController
+class PostController extends Controller
 {
 
     use Actions\FetchMany;
@@ -35,4 +40,22 @@ class PostController
     use Actions\AttachRelationship;
     use Actions\DetachRelationship;
 
+    /**
+     * Publish a post.
+     *
+     * @param Store $store
+     * @param Post $post
+     * @return DataResponse
+     */
+    public function publish(Store $store, Post $post)
+    {
+        $post->update(['published_at' => now()]);
+
+//        $model = $store
+//            ->queryOne('posts', $post)
+//            ->using($request)
+//            ->first();
+
+        return new DataResponse($post);
+    }
 }

--- a/tests/dummy/app/Http/Controllers/Api/V1/PostController.php
+++ b/tests/dummy/app/Http/Controllers/Api/V1/PostController.php
@@ -44,17 +44,18 @@ class PostController extends Controller
      * Publish a post.
      *
      * @param Store $store
+     * @param PostQuery $query
      * @param Post $post
      * @return DataResponse
      */
-    public function publish(Store $store, Post $post)
+    public function publish(Store $store, PostQuery $query, Post $post)
     {
         $post->update(['published_at' => now()]);
 
-//        $model = $store
-//            ->queryOne('posts', $post)
-//            ->using($request)
-//            ->first();
+        $model = $store
+            ->queryOne('posts', $post)
+            ->using($query)
+            ->first();
 
         return new DataResponse($post);
     }

--- a/tests/dummy/app/JsonApi/V1/Posts/PostQuery.php
+++ b/tests/dummy/app/JsonApi/V1/Posts/PostQuery.php
@@ -26,6 +26,23 @@ class PostQuery extends ResourceQuery
 {
 
     /**
+     * Authorize the request.
+     *
+     * @return bool|null
+     */
+    public function authorize(): ?bool
+    {
+        if ($this->is('*-actions*')) {
+            return (bool) optional($this->user())->can(
+                'update',
+                $this->model()
+            );
+        }
+
+        return null;
+    }
+
+    /**
      * Get the validation rules that apply to the request.
      *
      * @return array

--- a/tests/dummy/app/Models/User.php
+++ b/tests/dummy/app/Models/User.php
@@ -53,4 +53,12 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    /**
+     * @return bool
+     */
+    public function isAdmin(): bool
+    {
+        return 'support@example.com' === $this->email;
+    }
 }

--- a/tests/dummy/app/Policies/PostPolicy.php
+++ b/tests/dummy/app/Policies/PostPolicy.php
@@ -146,6 +146,15 @@ class PostPolicy
 
     /**
      * @param User|null $user
+     * @return bool
+     */
+    public function deleteAll(?User $user): bool
+    {
+        return $user && $user->isAdmin();
+    }
+
+    /**
+     * @param User|null $user
      * @param Post $post
      * @return bool
      */

--- a/tests/dummy/database/factories/UserFactory.php
+++ b/tests/dummy/database/factories/UserFactory.php
@@ -47,4 +47,12 @@ class UserFactory extends Factory
             'remember_token' => Str::random(10),
         ];
     }
+
+    /**
+     * @return UserFactory
+     */
+    public function admin(): self
+    {
+        return $this->state(['email' => 'support@example.com']);
+    }
 }

--- a/tests/dummy/routes/api.php
+++ b/tests/dummy/routes/api.php
@@ -1,7 +1,5 @@
 <?php
 
-use App\Http\Controllers\Api\V1\PostController;
-use Illuminate\Support\Facades\Route;
 use LaravelJsonApi\Laravel\Facades\JsonApiRoute;
 
 JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\V1')->resources(function ($server) {
@@ -9,9 +7,9 @@ JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\V1')->resources(functio
         $relationships->hasOne('author')->readOnly();
         $relationships->hasMany('comments')->readOnly();
         $relationships->hasMany('tags');
+    })->actions('-actions', function ($actions) {
+        $actions->withId()->post('publish');
     });
-
-    Route::post('posts/{post}/-actions/publish', [PostController::class, 'publish']);
 
     $server->resource('videos')->relationships(function ($relationships) {
         $relationships->hasMany('tags');

--- a/tests/dummy/routes/api.php
+++ b/tests/dummy/routes/api.php
@@ -3,14 +3,17 @@
 use LaravelJsonApi\Laravel\Facades\JsonApiRoute;
 
 JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\V1')->resources(function ($server) {
+    /** Posts */
     $server->resource('posts')->relationships(function ($relationships) {
         $relationships->hasOne('author')->readOnly();
         $relationships->hasMany('comments')->readOnly();
         $relationships->hasMany('tags');
     })->actions('-actions', function ($actions) {
-        $actions->withId()->post('publish');
+        $actions->delete('purge')->name('purge');
+        $actions->withId()->post('publish')->name('publish');
     });
 
+    /** Videos */
     $server->resource('videos')->relationships(function ($relationships) {
         $relationships->hasMany('tags');
     });

--- a/tests/dummy/routes/api.php
+++ b/tests/dummy/routes/api.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Controllers\Api\V1\PostController;
+use Illuminate\Support\Facades\Route;
 use LaravelJsonApi\Laravel\Facades\JsonApiRoute;
 
 JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\V1')->resources(function ($server) {
@@ -8,6 +10,8 @@ JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\V1')->resources(functio
         $relationships->hasMany('comments')->readOnly();
         $relationships->hasMany('tags');
     });
+
+    Route::post('posts/{post}/-actions/publish', [PostController::class, 'publish']);
 
     $server->resource('videos')->relationships(function ($relationships) {
         $relationships->hasMany('tags');

--- a/tests/dummy/routes/api.php
+++ b/tests/dummy/routes/api.php
@@ -9,8 +9,8 @@ JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\V1')->resources(functio
         $relationships->hasMany('comments')->readOnly();
         $relationships->hasMany('tags');
     })->actions('-actions', function ($actions) {
-        $actions->delete('purge')->name('purge');
-        $actions->withId()->post('publish')->name('publish');
+        $actions->delete('purge');
+        $actions->withId()->post('publish');
     });
 
     /** Videos */

--- a/tests/dummy/tests/Api/V1/Posts/Actions/PublishTest.php
+++ b/tests/dummy/tests/Api/V1/Posts/Actions/PublishTest.php
@@ -17,7 +17,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Api\V1\Posts;
+namespace App\Tests\Api\V1\Posts\Actions;
 
 use App\Models\Post;
 use App\Models\User;

--- a/tests/dummy/tests/Api/V1/Posts/Actions/PurgeTest.php
+++ b/tests/dummy/tests/Api/V1/Posts/Actions/PurgeTest.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\V1\Posts\Actions;
+
+use App\Models\Post;
+use App\Models\User;
+use App\Tests\Api\V1\TestCase;
+
+class PurgeTest extends TestCase
+{
+
+    public function test(): void
+    {
+        Post::factory()->count(3)->create();
+
+        $response = $this
+            ->actingAs(User::factory()->admin()->create())
+            ->jsonApi('posts')
+            ->delete('/api/v1/posts/-actions/purge');
+
+        $response->assertNoContent();
+
+        $this->assertDatabaseCount('posts', 0);
+    }
+
+    public function testForbidden(): void
+    {
+        Post::factory()->count(3)->create();
+
+        $response = $this
+            ->actingAs(User::factory()->create())
+            ->jsonApi('posts')
+            ->delete('/api/v1/posts/-actions/purge');
+
+        $response->assertForbidden();
+
+        $this->assertDatabaseCount('posts', 3);
+    }
+}

--- a/tests/dummy/tests/Api/V1/Posts/PublishTest.php
+++ b/tests/dummy/tests/Api/V1/Posts/PublishTest.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\V1\Posts;
+
+use App\Models\Post;
+use App\Tests\Api\V1\TestCase;
+
+class PublishTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $this->travelTo($date = now()->milliseconds(0));
+
+        $post = Post::factory()->create(['published_at' => null]);
+
+        $expected = $this->serializer
+            ->post($post)
+            ->replace('publishedAt', $date->jsonSerialize())
+            ->jsonSerialize();
+
+        $response = $this
+            ->withoutExceptionHandling()
+            ->actingAs($post->author)
+            ->jsonApi('posts')
+            ->contentType('application/json')
+            ->post(url('/api/v1/posts', [$post, '-actions/publish']));
+
+        $response->assertFetchedOneExact($expected);
+
+        $this->assertDatabaseHas('posts', array_replace(
+            $post->getAttributes(),
+            ['published_at' => $date->toDateTimeString()]
+        ));
+    }
+}

--- a/tests/lib/Integration/Routing/ActionsTest.php
+++ b/tests/lib/Integration/Routing/ActionsTest.php
@@ -1,0 +1,185 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Laravel\Tests\Integration\Routing;
+
+use LaravelJsonApi\Laravel\Facades\JsonApiRoute;
+
+class ActionsTest extends TestCase
+{
+
+    /**
+     * @return array
+     */
+    public function methodProvider(): array
+    {
+        return [
+            'GET' => ['GET'],
+            'POST' => ['POST'],
+            'PATCH' => ['PATCH'],
+            'PUT' => ['PUT'],
+            'DELETE' => ['DELETE'],
+            'OPTIONS' => ['OPTIONS'],
+        ];
+    }
+
+    /**
+     * @param string $method
+     * @dataProvider methodProvider
+     */
+    public function testBase(string $method): void
+    {
+        $func = strtolower($method);
+        $server = $this->createServer('v1');
+        $this->createSchema($server, 'posts', '\d+');
+
+        $this->defaultApiRoutesWithNamespace(function () use ($func) {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->resources(function ($server) use ($func) {
+                    $server->resource('posts')->actions(function ($actions) use ($func) {
+                        $actions->{$func}('foo-bar')->name('foobar');
+                    });
+                });
+        });
+
+        $route = $this->assertMatch($method, '/api/v1/posts/foo-bar');
+        $this->assertSame("App\Http\Controllers\Api\V1\PostController@fooBar", $route->action['controller']);
+        $this->assertSame("v1.posts.foobar", $route->getName());
+        $this->assertSame(['api', 'jsonapi:v1'], $route->action['middleware']);
+        $this->assertSame('posts', $route->parameter('resource_type'));
+        $this->assertNull($route->parameter('resource_id_name'));
+        $this->assertArrayNotHasKey('post', $route->wheres);
+    }
+
+    /**
+     * @param string $method
+     * @dataProvider methodProvider
+     */
+    public function testBaseWithPrefix(string $method): void
+    {
+        $func = strtolower($method);
+        $server = $this->createServer('v1');
+        $this->createSchema($server, 'posts', '\d+');
+
+        $this->defaultApiRoutesWithNamespace(function () use ($func) {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->resources(function ($server) use ($func) {
+                    $server->resource('posts')->actions('-actions', function ($actions) use ($func) {
+                        $actions->{$func}('foo-bar')->name('foobar');
+                    });
+                });
+        });
+
+        $route = $this->assertMatch($method, '/api/v1/posts/-actions/foo-bar');
+        $this->assertSame("App\Http\Controllers\Api\V1\PostController@fooBar", $route->action['controller']);
+        $this->assertSame("v1.posts.foobar", $route->getName());
+        $this->assertSame(['api', 'jsonapi:v1'], $route->action['middleware']);
+        $this->assertSame('posts', $route->parameter('resource_type'));
+        $this->assertNull($route->parameter('resource_id_name'));
+        $this->assertArrayNotHasKey('post', $route->wheres);
+    }
+
+    /**
+     * @param string $method
+     * @dataProvider methodProvider
+     */
+    public function testId(string $method): void
+    {
+        $func = strtolower($method);
+        $server = $this->createServer('v1');
+        $this->createSchema($server, 'posts', '\d+');
+
+        $this->defaultApiRoutesWithNamespace(function () use ($func) {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->resources(function ($server) use ($func) {
+                    $server->resource('posts')->actions(function ($actions) use ($func) {
+                        $actions->withId()->{$func}('foo-bar')->name('foobar');
+                    });
+                });
+        });
+
+        $route = $this->assertMatch($method, '/api/v1/posts/123/foo-bar');
+        $this->assertSame("App\Http\Controllers\Api\V1\PostController@fooBar", $route->action['controller']);
+        $this->assertSame("v1.posts.foobar", $route->getName());
+        $this->assertSame(['api', 'jsonapi:v1'], $route->action['middleware']);
+        $this->assertSame('posts', $route->parameter('resource_type'));
+        $this->assertSame('post', $route->parameter('resource_id_name'));
+        $this->assertSame('\d+', $route->wheres['post'] ?? null);
+    }
+
+    /**
+     * @param string $method
+     * @dataProvider methodProvider
+     */
+    public function testIdWithPrefix(string $method): void
+    {
+        $func = strtolower($method);
+        $server = $this->createServer('v1');
+        $this->createSchema($server, 'posts', '\d+');
+
+        $this->defaultApiRoutesWithNamespace(function () use ($func) {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->resources(function ($server) use ($func) {
+                    $server->resource('posts')->actions('-actions', function ($actions) use ($func) {
+                        $actions->withId()->{$func}('foo-bar')->name('foobar');
+                    });
+                });
+        });
+
+        $route = $this->assertMatch($method, '/api/v1/posts/123/-actions/foo-bar');
+        $this->assertSame("App\Http\Controllers\Api\V1\PostController@fooBar", $route->action['controller']);
+        $this->assertSame("v1.posts.foobar", $route->getName());
+        $this->assertSame(['api', 'jsonapi:v1'], $route->action['middleware']);
+        $this->assertSame('posts', $route->parameter('resource_type'));
+        $this->assertSame('post', $route->parameter('resource_id_name'));
+        $this->assertSame('\d+', $route->wheres['post'] ?? null);
+    }
+
+    /**
+     * @param string $method
+     * @dataProvider methodProvider
+     */
+    public function testIdConstraintWorks(string $method): void
+    {
+        $func = strtolower($method);
+        $server = $this->createServer('v1');
+        $this->createSchema($server, 'posts', '\d+');
+
+        $this->defaultApiRoutesWithNamespace(function () use ($func) {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->resources(function ($server) use ($func) {
+                    $server->resource('posts')->actions('-actions', function ($actions) use ($func) {
+                        $actions->withId()->{$func}('foo-bar')->name('foobar');
+                    });
+                });
+        });
+
+        $this->assertNotFound($method, '/api/v1/posts/123abc/-actions/foo-bar');
+    }
+}

--- a/tests/lib/Integration/Routing/HasManyTest.php
+++ b/tests/lib/Integration/Routing/HasManyTest.php
@@ -454,4 +454,30 @@ class HasManyTest extends TestCase
         $this->assertSame('post', $route->parameter('resource_id_name'));
         $this->assertSame('tags', $route->parameter('resource_relationship'));
     }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @dataProvider genericProvider
+     */
+    public function testIdConstraintWorks(string $method, string $uri): void
+    {
+        $server = $this->createServer('v1');
+        $schema = $this->createSchema($server, 'posts', '\d+');
+        $this->createRelation($schema, 'tags');
+
+        $this->defaultApiRoutesWithNamespace(function () {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->resources(function ($server) {
+                    $server->resource('posts')->relationships(function ($relations) {
+                        $relations->hasMany('tags');
+                    });
+                });
+        });
+
+        $this->assertMatch($method, $uri);
+        $this->assertNotFound($method, str_replace('123', '123abc', $uri));
+    }
 }

--- a/tests/lib/Integration/Routing/HasOneTest.php
+++ b/tests/lib/Integration/Routing/HasOneTest.php
@@ -386,4 +386,30 @@ class HasOneTest extends TestCase
         $this->assertSame('author', $route->parameter('resource_relationship'));
     }
 
+    /**
+     * @param string $method
+     * @param string $uri
+     * @dataProvider genericProvider
+     */
+    public function testIdConstraintWorks(string $method, string $uri): void
+    {
+        $server = $this->createServer('v1');
+        $schema = $this->createSchema($server, 'posts', '\d+');
+        $this->createRelation($schema, 'author');
+
+        $this->defaultApiRoutesWithNamespace(function () {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->resources(function ($server) {
+                    $server->resource('posts')->relationships(function ($relations) {
+                        $relations->hasOne('author');
+                    });
+                });
+        });
+
+        $this->assertMatch($method, $uri);
+        $this->assertNotFound($method, str_replace('123', '123abc', $uri));
+    }
+
 }

--- a/tests/lib/Integration/Routing/ResourceTest.php
+++ b/tests/lib/Integration/Routing/ResourceTest.php
@@ -469,4 +469,34 @@ class ResourceTest extends TestCase
         ]);
     }
 
+    /**
+     * @return array
+     */
+    public function resourceMethodProvider(): array
+    {
+        return [
+            'GET' => ['GET'],
+            'PATCH' => ['PATCH'],
+            'DELETE' => ['DELETE'],
+        ];
+    }
+
+    /**
+     * @param string $method
+     * @dataProvider resourceMethodProvider
+     */
+    public function testIdConstraintWorks(string $method): void
+    {
+        $server = $this->createServer('v1');
+        $this->createSchema($server, 'posts', '\d+');
+
+        $this->defaultApiRoutesWithNamespace(function () {
+            JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\\V1')->resources(function ($server) {
+                $server->resource('posts');
+            });
+        });
+
+        $this->assertMatch($method, '/api/v1/posts/123');
+        $this->assertNotFound($method, '/api/v1/posts/123abc');
+    }
 }


### PR DESCRIPTION
Adds support for registering custom actions for resources. Although this deviates from the JSON:API spec, it is something that is regularly request or queried via Github issues.

Example:

```php
$server->resource('posts')->actions('-actions', function ($actions) {
    $actions->delete('purge');
    $actions->withId()->post('publish');
});
```

Registers the following routes:

```
DELETE /api/v1/posts/-actions/purge
    -> PostController@purge
POST /api/v1/posts/{post}/-actions/publish
    -> PostController@publish
```

Supports all the usual methods - `get`, `post`, `patch`, `put`, `delete` and `options`.

It is recommended to use a prefix that avoids potential collisions with any future additions to the JSON:API spec - so in the example, we use `/-actions` instead of `/actions`. The prefix is optional, for example:

```php
$server->resource('posts')->actions(function ($actions) {
    $actions->delete('purge');
    $actions->withId()->post('publish');
});
```

Registers the following routes:

```
DELETE /api/v1/posts/purge
POST /api/v1/posts/{post}/publish
```

The controller method name is camelised, but this can be overidden using the second method argument:

```php
// PostController@fooBar
$actions->delete('foo-bar');

// PostController@foobar
$actions->delete('foo-bar', 'foobar');
```