### PR TITLE
[Feature] Support polymorphic to-many relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ All notable changes to this project will be documented in this file. This projec
   full details on how to apply this to resource schemas, refer to the new *Soft Deleting* chapter in the documentation.
 - Multi-resource models are now supported. This allows developers to represent a single model class as multiple
   different JSON:API resource types within an API. Refer to documentation for details of how to implement.
+- [#8](https://github.com/laravel-json-api/laravel/issues/8) The new `MorphToMany` relation field can now be used to add
+  polymorphic to-many relations to a schema. Refer to documentation for details.
 - Developers can now type-hint dependencies in their server's `serving()` method.
+- Can now manually register request, query and collection query classes using the `RequestResolver::registerRequest()`,
+  `RequestResolver::registerQuery()` and `RequestResolver::registerCollectionQuery()` static methods.
 
 ## [1.0.0-alpha.4] - 2021-02-27
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "laravel-json-api/encoder-neomerx": "^1.0.0-alpha.4",
         "laravel-json-api/exceptions": "^1.0.0-alpha.2",
         "laravel-json-api/spec": "^1.0.0-alpha.4",
-        "laravel-json-api/validation": "^1.0.0-alpha.4",
+        "laravel-json-api/validation": "^1.0.0-alpha.5",
         "laravel/framework": "^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "laravel-json-api/core": "^1.0.0-alpha.5",
-        "laravel-json-api/eloquent": "dev-feature/polymorphic-to-many",
+        "laravel-json-api/eloquent": "^1.0.0-alpha.5",
         "laravel-json-api/encoder-neomerx": "^1.0.0-alpha.4",
         "laravel-json-api/exceptions": "^1.0.0-alpha.2",
         "laravel-json-api/spec": "^1.0.0-alpha.4",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "laravel-json-api/core": "^1.0.0-alpha.5",
-        "laravel-json-api/eloquent": "^1.0.0-alpha.5",
+        "laravel-json-api/eloquent": "dev-feature/polymorphic-to-many",
         "laravel-json-api/encoder-neomerx": "^1.0.0-alpha.4",
         "laravel-json-api/exceptions": "^1.0.0-alpha.2",
         "laravel-json-api/spec": "^1.0.0-alpha.4",

--- a/tests/dummy/app/JsonApi/V1/Images/ImageSchema.php
+++ b/tests/dummy/app/JsonApi/V1/Images/ImageSchema.php
@@ -45,7 +45,7 @@ class ImageSchema extends Schema
     public function fields(): array
     {
         return [
-            ID::make(),
+            ID::make()->uuid(),
             DateTime::make('createdAt')->sortable()->readOnly(),
             Str::make('url'),
             DateTime::make('updatedAt')->sortable()->readOnly(),

--- a/tests/dummy/app/JsonApi/V1/Images/ImageSchema.php
+++ b/tests/dummy/app/JsonApi/V1/Images/ImageSchema.php
@@ -17,44 +17,27 @@
 
 declare(strict_types=1);
 
-namespace App\JsonApi\V1\Posts;
+namespace App\JsonApi\V1\Images;
 
-use App\Models\Post;
+use App\Models\Image;
 use LaravelJsonApi\Eloquent\Contracts\Paginator;
 use LaravelJsonApi\Eloquent\Fields\DateTime;
 use LaravelJsonApi\Eloquent\Fields\ID;
-use LaravelJsonApi\Eloquent\Fields\Relations\BelongsTo;
 use LaravelJsonApi\Eloquent\Fields\Relations\BelongsToMany;
-use LaravelJsonApi\Eloquent\Fields\Relations\HasMany;
-use LaravelJsonApi\Eloquent\Fields\Relations\MorphToMany;
-use LaravelJsonApi\Eloquent\Fields\SoftDelete;
 use LaravelJsonApi\Eloquent\Fields\Str;
-use LaravelJsonApi\Eloquent\Filters\OnlyTrashed;
-use LaravelJsonApi\Eloquent\Filters\Scope;
-use LaravelJsonApi\Eloquent\Filters\Where;
 use LaravelJsonApi\Eloquent\Filters\WhereIn;
 use LaravelJsonApi\Eloquent\Pagination\PagePagination;
 use LaravelJsonApi\Eloquent\Schema;
-use LaravelJsonApi\Eloquent\SoftDeletes;
 
-class PostSchema extends Schema
+class ImageSchema extends Schema
 {
-
-    use SoftDeletes;
 
     /**
      * The model the schema corresponds to.
      *
      * @var string
      */
-    public static string $model = Post::class;
-
-    /**
-     * The maximum depth of include paths.
-     *
-     * @var int
-     */
-    protected int $maxDepth = 3;
+    public static string $model = Image::class;
 
     /**
      * @inheritDoc
@@ -63,20 +46,8 @@ class PostSchema extends Schema
     {
         return [
             ID::make(),
-            BelongsTo::make('author')->type('users')->readOnly(),
-            HasMany::make('comments')->readOnly(),
-            Str::make('content'),
             DateTime::make('createdAt')->sortable()->readOnly(),
-            SoftDelete::make('deletedAt')->sortable(),
-            MorphToMany::make('media', [
-                BelongsToMany::make('images'),
-                BelongsToMany::make('videos'),
-            ]),
-            DateTime::make('publishedAt')->sortable(),
-            Str::make('slug'),
-            Str::make('synopsis'),
-            BelongsToMany::make('tags'),
-            Str::make('title')->sortable(),
+            Str::make('url'),
             DateTime::make('updatedAt')->sortable()->readOnly(),
         ];
     }
@@ -88,9 +59,6 @@ class PostSchema extends Schema
     {
         return [
             WhereIn::make('id', $this->idColumn())->delimiter(','),
-            Scope::make('published', 'wherePublished')->asBoolean(),
-            Where::make('slug')->singular(),
-            OnlyTrashed::make('trashed'),
         ];
     }
 

--- a/tests/dummy/app/JsonApi/V1/Media/MediaCollectionQuery.php
+++ b/tests/dummy/app/JsonApi/V1/Media/MediaCollectionQuery.php
@@ -1,0 +1,63 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace App\JsonApi\V1\Media;
+
+use LaravelJsonApi\Laravel\Http\Requests\ResourceQuery;
+use LaravelJsonApi\Validation\Rule as JsonApiRule;
+
+class MediaCollectionQuery extends ResourceQuery
+{
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules(): array
+    {
+        return [
+            'fields' => [
+                'nullable',
+                'array',
+                JsonApiRule::fieldSets(),
+            ],
+            'filter' => [
+                'nullable',
+                'array',
+                JsonApiRule::notSupported(),
+            ],
+            'include' => [
+                'nullable',
+                'string',
+                JsonApiRule::includePathsForPolymorph(),
+            ],
+            'page' => [
+                'nullable',
+                'array',
+                JsonApiRule::notSupported(),
+            ],
+            'sort' => [
+                'nullable',
+                'string',
+                JsonApiRule::notSupported(),
+            ],
+        ];
+    }
+}

--- a/tests/dummy/app/JsonApi/V1/Media/MediaCollectionQuery.php
+++ b/tests/dummy/app/JsonApi/V1/Media/MediaCollectionQuery.php
@@ -41,7 +41,7 @@ class MediaCollectionQuery extends ResourceQuery
             'filter' => [
                 'nullable',
                 'array',
-                JsonApiRule::notSupported(),
+                JsonApiRule::filter(['id']),
             ],
             'include' => [
                 'nullable',

--- a/tests/dummy/app/JsonApi/V1/Posts/PostRequest.php
+++ b/tests/dummy/app/JsonApi/V1/Posts/PostRequest.php
@@ -41,6 +41,7 @@ class PostRequest extends ResourceRequest
         return [
             'content' => ['required', 'string'],
             'deletedAt' => ['nullable', JsonApiRule::dateTime()],
+            'media' => JsonApiRule::toMany(),
             'slug' => ['required', 'string', $unique],
             'synopsis' => ['required', 'string'],
             'tags' => JsonApiRule::toMany(),

--- a/tests/dummy/app/JsonApi/V1/Posts/PostResource.php
+++ b/tests/dummy/app/JsonApi/V1/Posts/PostResource.php
@@ -56,6 +56,8 @@ class PostResource extends JsonApiResource
         return [
             $this->relation('author')->showDataIfLoaded(),
             $this->relation('comments'),
+            $this->relation('media')
+                ->withData(fn() => $this->schema->relationship('media')->value($this->resource)),
             $this->relation('tags')->showDataIfLoaded(),
         ];
     }

--- a/tests/dummy/app/JsonApi/V1/Server.php
+++ b/tests/dummy/app/JsonApi/V1/Server.php
@@ -61,6 +61,7 @@ class Server extends BaseServer
     {
         return [
             Comments\CommentSchema::class,
+            Images\ImageSchema::class,
             Posts\PostSchema::class,
             Tags\TagSchema::class,
             Users\UserSchema::class,

--- a/tests/dummy/app/JsonApi/V1/Server.php
+++ b/tests/dummy/app/JsonApi/V1/Server.php
@@ -24,6 +24,7 @@ use App\Models\Post;
 use App\Models\Video;
 use Illuminate\Support\Facades\Auth;
 use LaravelJsonApi\Core\Server\Server as BaseServer;
+use LaravelJsonApi\Laravel\Http\Requests\RequestResolver;
 
 class Server extends BaseServer
 {
@@ -50,6 +51,8 @@ class Server extends BaseServer
         Video::creating(static function (Video $video) {
             $video->owner()->associate(Auth::user());
         });
+
+        RequestResolver::registerCollectionQuery('media', Media\MediaCollectionQuery::class);
     }
 
     /**

--- a/tests/dummy/app/Models/Image.php
+++ b/tests/dummy/app/Models/Image.php
@@ -39,6 +39,11 @@ class Image extends Model
     protected $primaryKey = 'uuid';
 
     /**
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * @var string[]
      */
     protected $fillable = ['url'];

--- a/tests/dummy/app/Models/Image.php
+++ b/tests/dummy/app/Models/Image.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class Image extends Model
+{
+
+    use HasFactory;
+
+    /**
+     * @var bool
+     */
+    public $incrementing = false;
+
+    /**
+     * @var string
+     */
+    protected $primaryKey = 'uuid';
+
+    /**
+     * @var string[]
+     */
+    protected $fillable = ['url'];
+
+    /**
+     * @inheritDoc
+     */
+    protected static function booting()
+    {
+        parent::booting();
+
+        self::creating(static function (self $model) {
+            $model->{$model->getKeyName()} = $model->{$model->getKeyName()} ?? Str::uuid()->toString();
+        });
+    }
+}

--- a/tests/dummy/app/Models/Post.php
+++ b/tests/dummy/app/Models/Post.php
@@ -21,6 +21,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -66,11 +67,27 @@ class Post extends Model
     }
 
     /**
+     * @return BelongsToMany
+     */
+    public function images(): BelongsToMany
+    {
+        return $this->belongsToMany(Image::class);
+    }
+
+    /**
      * @return MorphToMany
      */
     public function tags(): MorphToMany
     {
         return $this->morphToMany(Tag::class, 'taggable');
+    }
+
+    /**
+     * @return BelongsToMany
+     */
+    public function videos(): BelongsToMany
+    {
+        return $this->belongsToMany(Video::class);
     }
 
     /**

--- a/tests/dummy/app/Models/Video.php
+++ b/tests/dummy/app/Models/Video.php
@@ -41,6 +41,11 @@ class Video extends Model
     protected $primaryKey = 'uuid';
 
     /**
+     * @var string
+     */
+    protected $keyType = 'string';
+
+    /**
      * @var string[]
      */
     protected $fillable = ['title', 'url'];

--- a/tests/dummy/app/Policies/PostPolicy.php
+++ b/tests/dummy/app/Policies/PostPolicy.php
@@ -75,6 +75,16 @@ class PostPolicy
      * @param Post $post
      * @return bool
      */
+    public function viewMedia(?User $user, Post $post): bool
+    {
+        return $this->view($user, $post);
+    }
+
+    /**
+     * @param User|null $user
+     * @param Post $post
+     * @return bool
+     */
     public function viewTags(?User $user, Post $post): bool
     {
         return $this->view($user, $post);

--- a/tests/dummy/app/Policies/PostPolicy.php
+++ b/tests/dummy/app/Policies/PostPolicy.php
@@ -115,6 +115,17 @@ class PostPolicy
      * @param LazyRelation $tags
      * @return bool
      */
+    public function updateMedia(?User $user, Post $post, LazyRelation $tags): bool
+    {
+        return $this->author($user, $post);
+    }
+
+    /**
+     * @param User|null $user
+     * @param Post $post
+     * @param LazyRelation $tags
+     * @return bool
+     */
     public function updateTags(?User $user, Post $post, LazyRelation $tags): bool
     {
         $tags->collect()->each(fn(Tag $tag) => $tag);
@@ -128,9 +139,31 @@ class PostPolicy
      * @param LazyRelation $tags
      * @return bool
      */
+    public function attachMedia(?User $user, Post $post, LazyRelation $tags): bool
+    {
+        return $this->author($user, $post);
+    }
+
+    /**
+     * @param User|null $user
+     * @param Post $post
+     * @param LazyRelation $tags
+     * @return bool
+     */
     public function attachTags(?User $user, Post $post, LazyRelation $tags): bool
     {
         return $this->updateTags($user, $post, $tags);
+    }
+
+    /**
+     * @param User|null $user
+     * @param Post $post
+     * @param LazyRelation $tags
+     * @return bool
+     */
+    public function detachMedia(?User $user, Post $post, LazyRelation $tags): bool
+    {
+        return $this->author($user, $post);
     }
 
     /**

--- a/tests/dummy/database/factories/ImageFactory.php
+++ b/tests/dummy/database/factories/ImageFactory.php
@@ -1,0 +1,45 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Image;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ImageFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = Image::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'url' => $this->faker->url,
+        ];
+    }
+}

--- a/tests/dummy/database/migrations/2020_06_13_143800_create_post_and_video_tables.php
+++ b/tests/dummy/database/migrations/2020_06_13_143800_create_post_and_video_tables.php
@@ -47,6 +47,12 @@ class CreatePostAndVideoTables extends Migration
                 ->onUpdate('cascade');
         });
 
+        Schema::create('images', function (Blueprint $table) {
+            $table->uuid('uuid')->primary();
+            $table->timestamps();
+            $table->string('url');
+        });
+
         Schema::create('videos', function (Blueprint $table) {
             $table->uuid('uuid')->primary();
             $table->timestamps();
@@ -101,6 +107,42 @@ class CreatePostAndVideoTables extends Migration
                 ->on('tags')
                 ->cascadeOnUpdate()
                 ->cascadeOnDelete();
+        });
+
+        Schema::create('image_post', function (Blueprint $table) {
+            $table->uuid('image_uuid');
+            $table->unsignedBigInteger('post_id');
+            $table->primary(['image_uuid', 'post_id']);
+
+            $table->foreign('image_uuid')
+                ->references('uuid')
+                ->on('images')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+
+            $table->foreign('post_id')
+                ->references('id')
+                ->on('posts')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+        });
+
+        Schema::create('post_video', function (Blueprint $table) {
+            $table->unsignedBigInteger('post_id');
+            $table->uuid('video_uuid');
+            $table->primary(['post_id', 'video_uuid']);
+
+            $table->foreign('post_id')
+                ->references('id')
+                ->on('posts')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
+
+            $table->foreign('video_uuid')
+                ->references('uuid')
+                ->on('videos')
+                ->cascadeOnDelete()
+                ->cascadeOnUpdate();
         });
     }
 

--- a/tests/dummy/routes/api.php
+++ b/tests/dummy/routes/api.php
@@ -7,6 +7,7 @@ JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\V1')->resources(functio
     $server->resource('posts')->relationships(function ($relationships) {
         $relationships->hasOne('author')->readOnly();
         $relationships->hasMany('comments')->readOnly();
+        $relationships->hasMany('media')->readOnly();
         $relationships->hasMany('tags');
     })->actions('-actions', function ($actions) {
         $actions->delete('purge');

--- a/tests/dummy/routes/api.php
+++ b/tests/dummy/routes/api.php
@@ -7,7 +7,7 @@ JsonApiRoute::server('v1')->prefix('v1')->namespace('Api\V1')->resources(functio
     $server->resource('posts')->relationships(function ($relationships) {
         $relationships->hasOne('author')->readOnly();
         $relationships->hasMany('comments')->readOnly();
-        $relationships->hasMany('media')->readOnly();
+        $relationships->hasMany('media');
         $relationships->hasMany('tags');
     })->actions('-actions', function ($actions) {
         $actions->delete('purge');

--- a/tests/dummy/tests/Api/V1/Posts/ReadMediaTest.php
+++ b/tests/dummy/tests/Api/V1/Posts/ReadMediaTest.php
@@ -1,0 +1,101 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\V1\Posts;
+
+use App\Models\Image;
+use App\Models\Post;
+use App\Models\Tag;
+use App\Models\Video;
+use App\Tests\Api\V1\TestCase;
+
+class ReadMediaTest extends TestCase
+{
+
+    /**
+     * @var Post
+     */
+    private Post $post;
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->post = Post::factory()->create();
+    }
+
+    public function test(): void
+    {
+        $images = Image::factory()->count(2)->create();
+        $videos = Video::factory()->count(2)->create();
+
+        $this->post->images()->saveMany($images);
+        $this->post->videos()->saveMany($videos);
+
+        $expected = collect($images)->merge($videos)->map(fn ($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $response = $this
+            ->withoutExceptionHandling()
+            ->jsonApi('videos') // @TODO the test assertion should work without having to do this.
+            ->get(url('/api/v1/posts', [$this->post, 'media']));
+
+        $response->assertFetchedMany($expected);
+    }
+
+    public function testIncludePath(): void
+    {
+        $images = Image::factory()->count(2)->create();
+        $videos = Video::factory()->count(2)->create();
+
+        $this->post->images()->saveMany($images);
+        $this->post->videos()->saveMany($videos);
+
+        $expected = collect($images)->merge($videos)->map(fn ($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        /** @var Tag $tag */
+        $tag = Tag::factory()->create();
+        $tag->videos()->save($video = $videos[0]);
+
+        $response = $this
+            ->jsonApi('videos') // @TODO should be able to remove this
+            ->includePaths('tags')
+            ->get(url('/api/v1/posts', [$this->post, 'media']));
+
+        $response->willSeeType('comments')->assertFetchedMany($expected);
+        $response->assertIncluded([
+            ['type' => 'tags', 'id' => $tag],
+        ]);
+    }
+
+    public function testInvalidMediaType(): void
+    {
+        $this->jsonApi()
+            ->accept('text/html')
+            ->get(url('/api/v1/posts', [$this->post, 'media']))
+            ->assertStatus(406);
+    }
+}

--- a/tests/dummy/tests/Api/V1/Posts/UpdateMediaTest.php
+++ b/tests/dummy/tests/Api/V1/Posts/UpdateMediaTest.php
@@ -1,0 +1,201 @@
+<?php
+/*
+ * Copyright 2021 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\V1\Posts;
+
+use App\Models\Comment;
+use App\Models\Image;
+use App\Models\Post;
+use App\Models\User;
+use App\Models\Video;
+use App\Tests\Api\V1\TestCase;
+
+class UpdateMediaTest extends TestCase
+{
+
+    /**
+     * @var Post
+     */
+    private Post $post;
+
+    /**
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->post = Post::factory()->create();
+    }
+
+    public function test(): void
+    {
+        $existingImages = Image::factory()->count(2)->create();
+        $existingVideos = Video::factory()->count(2)->create();
+
+        $this->post->images()->saveMany($existingImages);
+        $this->post->videos()->saveMany($existingVideos);
+
+        $images = Image::factory()->count(1)->create()->push(
+            $existingImages->first()
+        );
+
+        $videos = Video::factory()->count(1)->create()->push(
+            $existingVideos->last()
+        );
+
+        $ids = collect($images)->merge($videos)->map(fn($model) => [
+            'type' => ($model instanceof Image) ? 'images' : 'videos',
+            'id' => (string) $model->getRouteKey(),
+        ])->all();
+
+        $response = $this
+            ->withoutExceptionHandling()
+            ->actingAs($this->post->author)
+            ->jsonApi('videos') // @TODO assertions should work without this.
+            ->withData($ids)
+            ->patch(url('/api/v1/posts', [$this->post, 'relationships', 'media']));
+
+        $response->assertFetchedToMany($ids);
+
+        $this->assertDatabaseCount('image_post', count($images));
+        $this->assertDatabaseCount('post_video', count($videos));
+
+        foreach ($images as $image) {
+            $this->assertDatabaseHas('image_post', [
+                'image_uuid' => $image->getKey(),
+                'post_id' => $this->post->getKey(),
+            ]);
+        }
+
+        foreach ($videos as $video) {
+            $this->assertDatabaseHas('post_video', [
+                'post_id' => $this->post->getKey(),
+                'video_uuid' => $video->getKey(),
+            ]);
+        }
+    }
+
+    public function testClear(): void
+    {
+        $existingImages = Image::factory()->count(1)->create();
+        $existingVideos = Video::factory()->count(1)->create();
+
+        $this->post->images()->saveMany($existingImages);
+        $this->post->videos()->saveMany($existingVideos);
+
+        $response = $this
+            ->actingAs($this->post->author)
+            ->jsonApi('videos')
+            ->withData([])
+            ->patch(url('/api/v1/posts', [$this->post, 'relationships', 'media']));
+
+        $response->assertFetchedNone();
+
+        $this->assertDatabaseMissing('image_post', ['post_id' => $this->post->getKey()]);
+        $this->assertDatabaseMissing('post_video', ['post_id' => $this->post->getKey()]);
+    }
+
+    public function testInvalid(): void
+    {
+        $comment = Comment::factory()->create();
+
+        $data = [
+            [
+                'type' => 'comments',
+                'id' => (string) $comment->getRouteKey(),
+            ],
+        ];
+
+        $response = $this
+            ->actingAs($this->post->author)
+            ->jsonApi('videos')
+            ->withData($data)
+            ->patch(url('/api/v1/posts', [$this->post, 'relationships', 'media']));
+
+        $response->assertExactErrorStatus([
+            'detail' => 'The media field must be a to-many relationship containing images, videos resources.',
+            'source' => ['pointer' => '/data/0'],
+            'status' => '422',
+            'title' => 'Unprocessable Entity',
+        ]);
+    }
+
+    public function testUnauthorized(): void
+    {
+        $existingImages = Image::factory()->count(1)->create();
+        $existingVideos = Video::factory()->count(1)->create();
+
+        $this->post->images()->saveMany($existingImages);
+        $this->post->videos()->saveMany($existingVideos);
+
+        $response = $this
+            ->jsonApi('videos')
+            ->withData([])
+            ->patch(url('/api/v1/posts', [$this->post, 'relationships', 'media']));
+
+        $response->assertStatus(401);
+
+        $this->assertDatabaseCount('image_post', 1);
+        $this->assertDatabaseCount('post_video', 1);
+    }
+
+    public function testForbidden(): void
+    {
+        $existingImages = Image::factory()->count(1)->create();
+        $existingVideos = Video::factory()->count(1)->create();
+
+        $this->post->images()->saveMany($existingImages);
+        $this->post->videos()->saveMany($existingVideos);
+
+        $response = $this
+            ->actingAs(User::factory()->create())
+            ->jsonApi('videos')
+            ->withData([])
+            ->patch(url('/api/v1/posts', [$this->post, 'relationships', 'media']));
+
+        $response->assertStatus(403);
+
+        $this->assertDatabaseCount('image_post', 1);
+        $this->assertDatabaseCount('post_video', 1);
+    }
+
+    public function testNotAcceptableMediaType(): void
+    {
+        $response = $this
+            ->actingAs($this->post->author)
+            ->jsonApi('posts')
+            ->accept('text/html')
+            ->withData([])
+            ->patch(url('/api/v1/posts', [$this->post, 'relationships', 'media']));
+
+        $response->assertStatus(406);
+    }
+
+    public function testUnsupportedMediaType(): void
+    {
+        $response = $this
+            ->actingAs($this->post->author)
+            ->jsonApi('posts')
+            ->contentType('application/json')
+            ->withData([])
+            ->patch(url('/api/v1/posts', [$this->post, 'relationships', 'media']));
+
+        $response->assertStatus(415);
+    }
+}

--- a/tests/dummy/tests/Api/V1/Serializer.php
+++ b/tests/dummy/tests/Api/V1/Serializer.php
@@ -64,6 +64,12 @@ class Serializer
                         'related' => "{$self}/comments",
                     ],
                 ],
+                'media' => [
+                    'links' => [
+                        'self' => "{$self}/relationships/media",
+                        'related' => "{$self}/media",
+                    ],
+                ],
                 'tags' => [
                     'links' => [
                         'self' => "{$self}/relationships/tags",

--- a/tests/dummy/tests/Api/V1/Serializer.php
+++ b/tests/dummy/tests/Api/V1/Serializer.php
@@ -43,13 +43,13 @@ class Serializer
             'id' => (string) $post->getRouteKey(),
             'attributes' => [
                 'content' => $post->content,
-                'createdAt' => $post->created_at->jsonSerialize(),
+                'createdAt' => optional($post->created_at)->jsonSerialize(),
                 'deletedAt' => optional($post->deleted_at)->jsonSerialize(),
                 'publishedAt' => optional($post->published_at)->jsonSerialize(),
                 'slug' => $post->slug,
                 'synopsis' => $post->synopsis,
                 'title' => $post->title,
-                'updatedAt' => $post->updated_at->jsonSerialize(),
+                'updatedAt' => optional($post->updated_at)->jsonSerialize(),
             ],
             'relationships' => [
                 'author' => [


### PR DESCRIPTION
Adds a `MorphToMany` relation field, that effectively wraps multiple relation fields, for example:

```php
MorphToMany::make('media', [
    BelongsToMany::make('images'),
    BelongsToMany::make('videos'),
]),
```

This relatonship aggregates the results from each of its sub-relations, with the value returned in either the `data` member of its relationship field, or in a relationship endpoint.

The field is writeable as long as:

1. every sub-relationship is writeable (implements `FillableToMany`); and
2. each resource type that can be in the relationships maps to a single sub-relation.

Include paths also work, with the include paths only being applied to the sub-relations for which the include path is valid.

Closes #8 