### PR TITLE
[feature] add a conditional separation between showRelated and showRelationship

### DIFF
--- a/src/Http/Requests/ResourceQuery.php
+++ b/src/Http/Requests/ResourceQuery.php
@@ -127,6 +127,16 @@ class ResourceQuery extends FormRequest implements QueryParameters
         }
 
         if ($this->isViewingRelationship()) {
+
+            if (method_exists($authorizer, 'showRelated')
+                && !\Str::of($this->url())->contains('relationships')) {
+                return $authorizer->showRelated(
+                    $this,
+                    $this->modelOrFail(),
+                    $this->jsonApi()->route()->fieldName(),
+                );
+            }
+
             return $authorizer->showRelationship(
                 $this,
                 $this->modelOrFail(),


### PR DESCRIPTION
regarding issue laravel-json-api/core#6
if method showRelated exists in the custom authorizer, the two relationship-routes :
/api/resource/{resource_id}/relatedResource
/api/resource/{resource_id}/relationships/relatedResource

will authorize differently