### PR TITLE
Update readme to link to the new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ See our website, [laraveljsonapi.io](https://laraveljsonapi.io)
 ### Tutorial
 
 New to JSON:API and/or Laravel JSON:API? Then
-the [Laravel JSON:API tutorial](https://laraveljsonapi.io/docs/1.0/tutorial/)
+the [Laravel JSON:API tutorial](https://laraveljsonapi.io/docs/2.0/tutorial/)
 is a great way to learn!
 
 Follow the tutorial to build a blog application with a JSON:API compliant API.


### PR DESCRIPTION
I was following the readme section in the documentation to install this package, but couldn't as 1.1 doesn't allow php8.1. Until I saw that I was browsing old documentation. This PR fixes the URL I clicked on - which is also the only one with a version number.