### PR TITLE
Allow value zero as resource id.

### DIFF
--- a/src/Routing/Route.php
+++ b/src/Routing/Route.php
@@ -99,7 +99,9 @@ class Route implements RouteContract
             throw new LogicException('No JSON API resource id name set on route.');
         }
 
-        if ($modelOrResourceId = $this->route->parameter($name)) {
+        $modelOrResourceId = $this->route->parameter($name);
+
+        if (!empty($modelOrResourceId) || '0' === $modelOrResourceId) {
             return $modelOrResourceId;
         }
 


### PR DESCRIPTION
This modification fix an issue related with the possibility to have a resource ID with value = "0" on routes #178 

Worked along side @lindyhopchris