### PR TITLE
Authorizer stub not implementing all Authorizer contract methods causing an error

### DIFF
--- a/stubs/authorizer.stub
+++ b/stubs/authorizer.stub
@@ -69,7 +69,20 @@ class {{ class }} implements Authorizer
     }
 
     /**
-     * Authorize the show-related and show-relationship controller action.
+     * Authorize the show-related controller action
+     *
+     * @param Request $request
+     * @param object $model
+     * @param string $fieldName
+     * @return bool
+     */
+    public function showRelated(Request $request, object $model, string $fieldName): bool
+    {
+        // TODO: Implement showRelated() method.
+    }
+
+    /**
+     * Authorize the show-relationship controller action.
      *
      * @param Request $request
      * @param object $model


### PR DESCRIPTION
Generating a new authorizer (like `php artisan jsonapi:authorizer blog --server=v1`) will have the application crash with an error as the showRelated method was not included out-of-the-box:

```
Class App\JsonApi\Authorizers\BlogAuthorizer contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (LaravelJsonApi\Contracts\Auth\Authorizer::showRelated)
```