### PR TITLE
[Fix] Override default Laravel method to check the type is an exact match

### DIFF
--- a/src/Http/Requests/ResourceQuery.php
+++ b/src/Http/Requests/ResourceQuery.php
@@ -316,6 +316,18 @@ class ResourceQuery extends FormRequest implements QueryParameters
     }
 
     /**
+     * Determine if the given content types match.
+     *
+     * @param  string  $actual
+     * @param  string  $type
+     * @return bool
+     */
+    public static function matchesType($actual, $type)
+    {
+        return $actual === $type;
+    }
+
+    /**
      * Get an exception if the media type is not acceptable.
      *
      * @return HttpExceptionInterface


### PR DESCRIPTION
Hi @lindyhopchris ; hope you don't mind me giving this one ago. I've seen that there's a few issues and want to help as much as possible where I can.

I did some investigating into this one and it's because the way that the regex works within the illuminate source code and when it's split it matches due to the way that the split is done.

As we are only concerned if the header is an *exact* match to application/vnd.api+json then I would presume it is safe to override the method and check for an exact match disregarding the regex which is there in the illuminate source code.

I've added some tests to back up this which just check for a response with the correct header and a response with an invalid header.

Addresses #184