### PR TITLE
Allow null as data in relationship PATCH request

### DIFF
--- a/src/Http/Requests/ResourceRequest.php
+++ b/src/Http/Requests/ResourceRequest.php
@@ -204,7 +204,7 @@ class ResourceRequest extends FormRequest
     {
         $document = $this->json()->all();
 
-        if (!is_array($document) || !isset($document['data']) || !is_array($document['data'])) {
+        if (!is_array($document) || !array_key_exists('data', $document) || !(is_array($document['data']) || is_null($document['data']))) {
             throw new LogicException('Expecting JSON API specification compliance to have been run.');
         }
 


### PR DESCRIPTION
This allows you to remove a to-one relationship by sending `null` in a PATCH request, as described in the [spec](https://jsonapi.org/format/#crud-updating-to-one-relationships).

## Request
PATCH {{baseUrl}}/model/:model/relationships/related
```json
{
  "data": null
}
```

## Result
### Before
```json
{
    "jsonapi": {
        "version": "1.0"
    },
    "errors": [
        {
            "detail": "Expecting JSON API specification compliance to have been run.",
            "meta": {
                "exception": "LogicException",
                "file": "vendor/laravel-json-api/laravel/src/Http/Requests/ResourceRequest.php",
                "line": 209,
                "trace": []
            },
            "status": "500",
            "title": "Internal Server Error"
        }
    ]
}
```

### After
```json
{
    "jsonapi": {
        "version": "1.0"
    },
    "links": {
        "related": "{{baseUrl}}/model/1/related",
        "self": "{{baseUrl}}/model/1/relationships/related"
    },
    "data": null
}
```