### PR TITLE
Add configuration setting for 'route action middleware'

### DIFF
--- a/src/Routing/PendingRelationshipRegistration.php
+++ b/src/Routing/PendingRelationshipRegistration.php
@@ -164,6 +164,20 @@ class PendingRelationshipRegistration
 
         return $this;
     }
+    
+
+    /**
+     * Add middleware to the resource routes.
+     *
+     * @param Closure|array<string, string|string[]> $middleware
+     * @return $this
+     */
+    public function routeActionMiddleware(array|\Closure $middleware): self
+    {
+        $this->options['route_action_middleware'] = $middleware;
+
+        return $this;
+    }
 
     /**
      * Specify middleware that should be removed from the resource routes.

--- a/src/Routing/PendingResourceRegistration.php
+++ b/src/Routing/PendingResourceRegistration.php
@@ -189,6 +189,20 @@ class PendingResourceRegistration
 
         return $this;
     }
+    
+
+    /**
+     * Add middleware to the resource routes.
+     *
+     * @param Closure|array<string, string|string[]> $middleware
+     * @return $this
+     */
+    public function routeActionMiddleware(array|Closure $middleware): self
+    {
+        $this->options['route_action_middleware'] = $middleware;
+
+        return $this;
+    }
 
     /**
      * Specify middleware that should be removed from the resource routes.

--- a/src/Routing/RelationshipRegistrar.php
+++ b/src/Routing/RelationshipRegistrar.php
@@ -276,9 +276,26 @@ class RelationshipRegistrar
         if (isset($options['middleware'])) {
             $action['middleware'] = $options['middleware'];
         }
-
+        
         if (isset($options['excluded_middleware'])) {
             $action['excluded_middleware'] = $options['excluded_middleware'];
+        }
+        if (isset($options['route_action_middleware'])) {
+            /** @var \closure<string[], string, string, string>|array<string, string|string[]> $routeMiddlewareMap */
+            $routeMiddlewareMap = $options['route_action_middleware'];
+            /** @var string|string[] $routeActionMiddleware */
+            $routeActionMiddleware = is_callable($routeMiddlewareMap) ? $routeMiddlewareMap(
+                Str::classify($this->resourceType),
+                Str::classify($method),
+                Str::classify($defaultName)
+            ) : ($routeMiddlewareMap[$method] ?? []);
+            /** @var string[] $newMiddleware */
+            $newMiddleware = is_array($routeActionMiddleware) ? $routeActionMiddleware : [$routeActionMiddleware];
+            /** @var string[] $oldMiddleware */
+            $oldMiddleware = $action['middleware'] ?? [];
+
+            // dd($oldMiddleware, $routeActionMiddleware);
+            $action['middleware'] = array_merge($oldMiddleware, $newMiddleware);
         }
 
         return $action;

--- a/src/Routing/ResourceRegistrar.php
+++ b/src/Routing/ResourceRegistrar.php
@@ -349,6 +349,23 @@ class ResourceRegistrar
         if (isset($options['excluded_middleware'])) {
             $action['excluded_middleware'] = $options['excluded_middleware'];
         }
+        
+        if (isset($options['route_action_middleware'])) {
+            /** @var \closure<string[], string, string, string>|array<string, string|string[]> $routeMiddlewareMap */
+            $routeMiddlewareMap = $options['route_action_middleware'];
+            /** @var string|string[] $routeActionMiddleware */
+            $routeActionMiddleware = is_callable($routeMiddlewareMap) ? $routeMiddlewareMap(
+                Str::classify($resourceType),
+                Str::classify($method),
+            ) : ($routeMiddlewareMap[$method] ?? []);
+            /** @var string[] $newMiddleware */
+            $newMiddleware = is_array($routeActionMiddleware) ? $routeActionMiddleware : [$routeActionMiddleware];
+            /** @var string[] $oldMiddleware */
+            $oldMiddleware = $action['middleware'] ?? [];
+
+            // dd($oldMiddleware, $routeActionMiddleware);
+            $action['middleware'] = array_merge($oldMiddleware, $newMiddleware);
+        }
 
         $action['where'] = $this->getWheres($resourceType, $parameter, $options);
 


### PR DESCRIPTION
Implements #265

Specifically, a developer can define **additional** middleware for route actions.
This change allows my server to successfully add my Oauth2.0 scope checks to my desired API endpoints.
I can successfully set the scopes as `User.Group.Update` or `User.Chat.Update` to my tokens, and be blocked on API requests if I don't have the required scope.

Note, that for my case, I defined a closure that I provide to each call of the `routeActionMiddleware` function. I'd still like to have it defined on the server once, but didn't see a way to implement that without significant refactors.

Finally, I can definitely clean this up as desired. Let me know if a different name/key is preferred, or if you want me to remove the type annotations.