### PR TITLE
Feature: upgrade to Laravel 11 and drop PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3]
-        laravel: [10]
+        php: [8.2, 8.3]
+        laravel: [11]
 
     steps:
       - name: Checkout Code

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /dummy
 vendor/
 composer.lock
-.phpunit.result.cache
-.phpunit.cache
+.phpunit.cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
-## Unreleased (Laravel 11)
+## Unreleased
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 All notable changes to this project will be documented in this file. This project adheres to
 [Semantic Versioning](http://semver.org/) and [this changelog format](http://keepachangelog.com/).
 
-## Unreleased
+## Unreleased (Laravel 11)
+
+### Changed
+
+- **BREAKING** Package now requires Laravel 11.
+- Minimum PHP version is now `8.2`.
 
 ## [3.4.0] - 2024-03-03
 

--- a/composer.json
+++ b/composer.json
@@ -53,8 +53,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "3.x-dev",
-            "dev-laravel11": "4.x-dev"
+            "dev-develop": "4.x-dev"
         },
         "laravel": {
             "aliases": {
@@ -66,7 +65,7 @@
             ]
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true,
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -23,20 +23,20 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "ext-json": "*",
-        "laravel-json-api/core": "^3.3",
-        "laravel-json-api/eloquent": "^3.1",
-        "laravel-json-api/encoder-neomerx": "^3.1",
-        "laravel-json-api/exceptions": "^2.1",
-        "laravel-json-api/spec": "^2.0",
-        "laravel-json-api/validation": "^3.0",
-        "laravel/framework": "^10.0"
+        "laravel-json-api/core": "^4.0",
+        "laravel-json-api/eloquent": "^4.0",
+        "laravel-json-api/encoder-neomerx": "^4.0",
+        "laravel-json-api/exceptions": "^3.0",
+        "laravel-json-api/spec": "^3.0",
+        "laravel-json-api/validation": "^4.0",
+        "laravel/framework": "^11.0"
     },
     "require-dev": {
-        "laravel-json-api/testing": "^2.1",
-        "orchestra/testbench": "^8.0",
-        "phpunit/phpunit": "^10.0"
+        "laravel-json-api/testing": "^3.0",
+        "orchestra/testbench": "^9.0",
+        "phpunit/phpunit": "^10.5"
     },
     "autoload": {
         "psr-4": {
@@ -53,7 +53,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-develop": "3.x-dev"
+            "dev-develop": "3.x-dev",
+            "dev-laravel11": "4.x-dev"
         },
         "laravel": {
             "aliases": {
@@ -65,7 +66,7 @@
             ]
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Changes required to upgrade to Laravel 11, dropping PHP 8.1 at the same time.

If you want to try in your application (if you're upgrading to Laravel 11):

```bash
composer config minimum-stability dev
composer require laravel-json-api/laravel:^4.0 --no-update
composer require laravel-json-api/testing:^3.0 --dev --no-update
composer up "cloudcreativity/*" "laravel-json-api/*"
```