### PR TITLE
Feature: allow middleware registration per action on resource and relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 
+### Added
+
+- [#265](https://github.com/laravel-json-api/laravel/issues/265) Allow registration of middleware per action on both
+  resource routes and relationship routes.
+
 ## [3.2.0] - 2023-11-08
 
 ### Added

--- a/src/Routing/PendingRelationshipRegistration.php
+++ b/src/Routing/PendingRelationshipRegistration.php
@@ -20,6 +20,7 @@ declare(strict_types=1);
 namespace LaravelJsonApi\Laravel\Routing;
 
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Arr;
 
 class PendingRelationshipRegistration
 {
@@ -155,12 +156,30 @@ class PendingRelationshipRegistration
     /**
      * Add middleware to the resource routes.
      *
-     * @param string ...$middleware
+     * @param mixed ...$middleware
      * @return $this
      */
-    public function middleware(string ...$middleware): self
+    public function middleware(...$middleware): self
     {
-        $this->options['middleware'] = $middleware;
+        if (count($middleware) === 1) {
+            $middleware = Arr::wrap($middleware[0]);
+        }
+
+        if (array_is_list($middleware)) {
+            $this->options['middleware'] = $middleware;
+            return $this;
+        }
+
+        $this->options['middleware'] = Arr::wrap($middleware['*'] ?? null);
+
+        foreach ($this->map as $alias => $action) {
+            if (isset($middleware[$alias])) {
+                $middleware[$action] = $middleware[$alias];
+                unset($middleware[$alias]);
+            }
+        }
+
+        $this->options['action_middleware'] = $middleware;
 
         return $this;
     }

--- a/src/Routing/PendingResourceRegistration.php
+++ b/src/Routing/PendingResourceRegistration.php
@@ -21,6 +21,7 @@ namespace LaravelJsonApi\Laravel\Routing;
 
 use Closure;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use function is_string;
 
@@ -180,12 +181,22 @@ class PendingResourceRegistration
     /**
      * Add middleware to the resource routes.
      *
-     * @param string ...$middleware
+     * @param mixed ...$middleware
      * @return $this
      */
-    public function middleware(string ...$middleware): self
+    public function middleware(...$middleware): self
     {
-        $this->options['middleware'] = $middleware;
+        if (count($middleware) === 1) {
+            $middleware = Arr::wrap($middleware[0]);
+        }
+
+        if (array_is_list($middleware)) {
+            $this->options['middleware'] = $middleware;
+            return $this;
+        }
+
+        $this->options['middleware'] = Arr::wrap($middleware['*'] ?? null);
+        $this->options['action_middleware'] = $middleware;
 
         return $this;
     }
@@ -196,7 +207,7 @@ class PendingResourceRegistration
      * @param string ...$middleware
      * @return $this
      */
-    public function withoutMiddleware(string ...$middleware)
+    public function withoutMiddleware(string ...$middleware): self
     {
         $this->options['excluded_middleware'] = array_merge(
             (array) ($this->options['excluded_middleware'] ?? []),

--- a/src/Routing/RelationshipRegistrar.php
+++ b/src/Routing/RelationshipRegistrar.php
@@ -22,6 +22,7 @@ namespace LaravelJsonApi\Laravel\Routing;
 use Illuminate\Contracts\Routing\Registrar as RegistrarContract;
 use Illuminate\Routing\Route as IlluminateRoute;
 use Illuminate\Routing\RouteCollection;
+use Illuminate\Support\Arr;
 use LaravelJsonApi\Contracts\Schema\Schema;
 use LaravelJsonApi\Core\Support\Str;
 
@@ -272,9 +273,10 @@ class RelationshipRegistrar
         $name = $this->getRelationRouteName($method, $defaultName, $options);
 
         $action = ['as' => $name, 'uses' => $this->controller.'@'.$method];
+        $middleware = $this->getMiddleware($method, $options);
 
-        if (isset($options['middleware'])) {
-            $action['middleware'] = $options['middleware'];
+        if (!empty($middleware)) {
+            $action['middleware'] = $middleware;
         }
 
         if (isset($options['excluded_middleware'])) {
@@ -282,6 +284,22 @@ class RelationshipRegistrar
         }
 
         return $action;
+    }
+
+    /**
+     * @param string $action
+     * @param array $options
+     * @return array
+     */
+    private function getMiddleware(string $action, array $options): array
+    {
+        $all = $options['middleware'] ?? [];
+        $actions = $options['action_middleware'] ?? [];
+
+        return [
+            ...$all,
+            ...Arr::wrap($actions[$action] ?? null),
+        ];
     }
 
     /**

--- a/tests/lib/Integration/Routing/HasOneTest.php
+++ b/tests/lib/Integration/Routing/HasOneTest.php
@@ -22,6 +22,8 @@ namespace LaravelJsonApi\Laravel\Tests\Integration\Routing;
 use Illuminate\Contracts\Routing\Registrar;
 use LaravelJsonApi\Core\Support\Arr;
 use LaravelJsonApi\Laravel\Facades\JsonApiRoute;
+use LaravelJsonApi\Laravel\Routing\Relationships;
+use LaravelJsonApi\Laravel\Routing\ResourceRegistrar;
 
 class HasOneTest extends TestCase
 {
@@ -117,11 +119,9 @@ class HasOneTest extends TestCase
     /**
      * @param string $method
      * @param string $uri
-     * @param string $action
-     * @param string $name
      * @dataProvider genericProvider
      */
-    public function testMiddleware(string $method, string $uri, string $action, string $name): void
+    public function testMiddleware(string $method, string $uri): void
     {
         $server = $this->createServer('v1');
         $schema = $this->createSchema($server, 'posts', '\d+');
@@ -134,13 +134,91 @@ class HasOneTest extends TestCase
                 ->middleware('foo')
                 ->resources(function ($server) {
                     $server->resource('posts')->middleware('bar')->relationships(function ($relations) {
-                        $relations->hasOne('author')->middleware('baz');
+                        $relations->hasOne('author')->middleware('baz1', 'baz2');
                     });
                 });
         });
 
         $route = $this->assertMatch($method, $uri);
-        $this->assertSame(['api', 'jsonapi:v1', 'foo', 'bar', 'baz'], $route->action['middleware']);
+        $this->assertSame(['api', 'jsonapi:v1', 'foo', 'bar', 'baz1', 'baz2'], $route->action['middleware']);
+    }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @dataProvider genericProvider
+     */
+    public function testMiddlewareAsArrayList(string $method, string $uri): void
+    {
+        $server = $this->createServer('v1');
+        $schema = $this->createSchema($server, 'posts', '\d+');
+        $this->createRelation($schema, 'author');
+
+        $this->defaultApiRoutesWithNamespace(function () {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->middleware('foo')
+                ->resources(function (ResourceRegistrar $server) {
+                    $server->resource('posts')->middleware('bar')->relationships(function (Relationships $relations) {
+                        $relations->hasOne('author')->middleware(['baz1', 'baz2']);
+                    });
+                });
+        });
+
+        $route = $this->assertMatch($method, $uri);
+        $this->assertSame(['api', 'jsonapi:v1', 'foo', 'bar', 'baz1', 'baz2'], $route->action['middleware']);
+    }
+
+    /**
+     * @param string $method
+     * @param string $uri
+     * @param string $action
+     * @dataProvider genericProvider
+     */
+    public function testActionMiddleware(string $method, string $uri, string $action): void
+    {
+        $actions = [
+            '*' => ['baz1', 'baz2'],
+            'showRelated' => 'showRelated1',
+            'showRelationship' => ['showRelationship1', 'showRelationship2'],
+            'updateRelationship' => 'updateRelationship1',
+        ];
+
+        $expected = [
+            'api',
+            'jsonapi:v1',
+            'foo',
+            'bar',
+            ...$actions['*'],
+            ...Arr::wrap($actions[$action]),
+        ];
+
+        $server = $this->createServer('v1');
+        $schema = $this->createSchema($server, 'posts', '\d+');
+        $this->createRelation($schema, 'author');
+
+        $this->defaultApiRoutesWithNamespace(function () use ($actions) {
+            JsonApiRoute::server('v1')
+                ->prefix('v1')
+                ->namespace('Api\\V1')
+                ->middleware('foo')
+                ->resources(function (ResourceRegistrar $server) use ($actions) {
+                    $server->resource('posts')->middleware('bar')->relationships(
+                        function (Relationships $relations) use ($actions) {
+                            $relations->hasOne('author')->middleware([
+                                '*' => $actions['*'],
+                                'related' => $actions['showRelated'],
+                                'show' => $actions['showRelationship'],
+                                'update' => $actions['updateRelationship'],
+                            ]);
+                        },
+                    );
+                });
+        });
+
+        $route = $this->assertMatch($method, $uri);
+        $this->assertSame($expected, $route->action['middleware']);
     }
 
     /**


### PR DESCRIPTION
See #265

This PR adds the ability to register middleware per action, on both resource and relationship routes.

Usage for resource:

```php
$server->resource('posts')->middleware([
    '*' => 'foo', // applied to all actions
    'show' => 'bar', // applied to just the show action
    'store' => ['baz1', 'baz2'], // use an array for multiple middleware
]);
```

Relationship is the same, using our short-hands for the actions:

```php
$relationships->hasMany('tags')->middleware([
    '*' => 'foo', // applied to all
    'related' => 'bar',
    'attach' => ['baz1', 'baz2'],
]);
```