### PR TITLE
feat: add support to replace model in resource stub

### DIFF
--- a/src/Console/Concerns/ReplacesModel.php
+++ b/src/Console/Concerns/ReplacesModel.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+declare(strict_types=1);
+
+namespace LaravelJsonApi\Laravel\Console\Concerns;
+
+use Illuminate\Support\Str;
+use function array_keys;
+use function array_values;
+use function str_replace;
+
+trait ReplacesModel
+{
+
+    /**
+     * @param string $stub
+     * @param string $model
+     * @return string
+     */
+    protected function replaceModel(string $stub, string $model): string
+    {
+        $model = str_replace('/', '\\', $model);
+
+        if (Str::startsWith($model, '\\')) {
+            $namespacedModel = trim($model, '\\');
+        } else {
+            $namespacedModel = $this->qualifyModel($model);
+        }
+
+        $model = class_basename($model);
+
+        $replace = [
+            '{{ namespacedModel }}' => $namespacedModel,
+            '{{namespacedModel}}' => $namespacedModel,
+            '{{ model }}' => $model,
+            '{{model}}' => $model,
+        ];
+
+        return str_replace(
+            array_keys($replace), array_values($replace), $stub
+        );
+    }
+}

--- a/src/Console/MakeResource.php
+++ b/src/Console/MakeResource.php
@@ -19,10 +19,12 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Laravel\Console;
 
+use LaravelJsonApi\Laravel\Console\Concerns\ReplacesModel;
 use Symfony\Component\Console\Input\InputOption;
 
 class MakeResource extends GeneratorCommand
 {
+    use ReplacesModel;
 
     /**
      * @var string
@@ -55,12 +57,24 @@ class MakeResource extends GeneratorCommand
     /**
      * @inheritDoc
      */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        $model = $this->option('model') ?: $this->guessModel();
+
+        return $this->replaceModel($stub, $model);
+    }
+
+    /**
+     * @inheritDoc
+     */
     protected function getOptions()
     {
         return [
             ['force', null, InputOption::VALUE_NONE, 'Create the class even if the resource already exists'],
+            ['model', 'm', InputOption::VALUE_REQUIRED, 'The model that the resource applies to.'],
             ['server', 's', InputOption::VALUE_REQUIRED, 'The JSON:API server the resource exists in.'],
         ];
     }
-
 }

--- a/src/Console/MakeSchema.php
+++ b/src/Console/MakeSchema.php
@@ -19,7 +19,7 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Laravel\Console;
 
-use Illuminate\Support\Str;
+use LaravelJsonApi\Laravel\Console\Concerns\ReplacesModel;
 use Symfony\Component\Console\Input\InputOption;
 use function array_keys;
 use function array_values;
@@ -27,6 +27,7 @@ use function str_replace;
 
 class MakeSchema extends GeneratorCommand
 {
+    use ReplacesModel;
 
     /**
      * @var string
@@ -47,7 +48,7 @@ class MakeSchema extends GeneratorCommand
      * @var string
      */
     protected $classType = 'Schema';
-
+    
     /**
      * @inheritDoc
      */
@@ -65,7 +66,7 @@ class MakeSchema extends GeneratorCommand
      */
     protected function buildClass($name)
     {
-        $stub = parent::buildClass($name);
+        $stub = $this->replaceSchema(parent::buildClass($name));
 
         $model = $this->option('model') ?: $this->guessModel();
 
@@ -77,24 +78,11 @@ class MakeSchema extends GeneratorCommand
      * @param string $model
      * @return string
      */
-    protected function replaceModel(string $stub, string $model): string
+    protected function replaceSchema(string $stub): string
     {
-        $model = str_replace('/', '\\', $model);
-
-        if (Str::startsWith($model, '\\')) {
-            $namespacedModel = trim($model, '\\');
-        } else {
-            $namespacedModel = $this->qualifyModel($model);
-        }
-
-        $model = class_basename($model);
         $schema = $this->option('proxy') ? 'ProxySchema' : 'Schema';
 
         $replace = [
-            '{{ namespacedModel }}' => $namespacedModel,
-            '{{namespacedModel}}' => $namespacedModel,
-            '{{ model }}' => $model,
-            '{{model}}' => $model,
             '{{ schema }}' => $schema,
             '{{schema}}' => $schema,
         ];
@@ -117,5 +105,4 @@ class MakeSchema extends GeneratorCommand
             ['server', 's', InputOption::VALUE_REQUIRED, 'The JSON:API server the schema exists in.'],
         ];
     }
-
 }

--- a/stubs/resource.stub
+++ b/stubs/resource.stub
@@ -2,9 +2,13 @@
 
 namespace {{ namespace }};
 
+use {{ namespacedModel }};
 use Illuminate\Http\Request;
 use LaravelJsonApi\Core\Resources\JsonApiResource;
 
+/**
+ * @property {{ model }} $resource
+ */
 class {{ class }} extends JsonApiResource
 {
 
@@ -17,8 +21,8 @@ class {{ class }} extends JsonApiResource
     public function attributes($request): iterable
     {
         return [
-            'createdAt' => $this->created_at,
-            'updatedAt' => $this->updated_at,
+            'createdAt' => $this->resource->created_at,
+            'updatedAt' => $this->resource->updated_at,
         ];
     }
 


### PR DESCRIPTION
To better support phpstan/code discoverability it would be ideal to expose the related model to the resource - this PR just moves the model replacement logic into a trait so that it can be shared by both the schema and resource commands.

I've then updated the resource stub accordingly 👍 