### PR TITLE
feat: Allow creating FormRequests by methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 composer.lock
 .phpunit.cache/
+.idea/

--- a/src/Http/Controllers/Actions/AttachRelationship.php
+++ b/src/Http/Controllers/Actions/AttachRelationship.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Response;
 use LaravelJsonApi\Contracts\Routing\Route;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
 use LaravelJsonApi\Core\Support\Str;
+use LaravelJsonApi\Laravel\Http\Requests\RequestMethod;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceQuery;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceRequest;
 use LogicException;
@@ -41,7 +42,8 @@ trait AttachRelationship
         }
 
         $request = ResourceRequest::forResource(
-            $resourceType = $route->resourceType()
+            $resourceType = $route->resourceType(),
+            RequestMethod::ATTACH_RELATIONSHIP
         );
 
         $query = ResourceQuery::queryMany($relation->inverse());

--- a/src/Http/Controllers/Actions/DetachRelationship.php
+++ b/src/Http/Controllers/Actions/DetachRelationship.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Response;
 use LaravelJsonApi\Contracts\Routing\Route;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
 use LaravelJsonApi\Core\Support\Str;
+use LaravelJsonApi\Laravel\Http\Requests\RequestMethod;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceQuery;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceRequest;
 use LogicException;
@@ -41,7 +42,8 @@ trait DetachRelationship
         }
 
         $request = ResourceRequest::forResource(
-            $resourceType = $route->resourceType()
+            $resourceType = $route->resourceType(),
+            RequestMethod::DETACH_RELATIONSHIP
         );
 
         $query = ResourceQuery::queryMany($relation->inverse());

--- a/src/Http/Controllers/Actions/Store.php
+++ b/src/Http/Controllers/Actions/Store.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Response;
 use LaravelJsonApi\Contracts\Routing\Route;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
 use LaravelJsonApi\Core\Responses\DataResponse;
+use LaravelJsonApi\Laravel\Http\Requests\RequestMethod;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceQuery;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceRequest;
 
@@ -32,7 +33,8 @@ trait Store
     public function store(Route $route, StoreContract $store)
     {
         $request = ResourceRequest::forResource(
-            $resourceType = $route->resourceType()
+            $resourceType = $route->resourceType(),
+            RequestMethod::STORE
         );
 
         $query = ResourceQuery::queryOne($resourceType);

--- a/src/Http/Controllers/Actions/Update.php
+++ b/src/Http/Controllers/Actions/Update.php
@@ -16,6 +16,7 @@ use Illuminate\Http\Response;
 use LaravelJsonApi\Contracts\Routing\Route;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
 use LaravelJsonApi\Core\Responses\DataResponse;
+use LaravelJsonApi\Laravel\Http\Requests\RequestMethod;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceQuery;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceRequest;
 
@@ -32,7 +33,8 @@ trait Update
     public function update(Route $route, StoreContract $store)
     {
         $request = ResourceRequest::forResource(
-            $resourceType = $route->resourceType()
+            $resourceType = $route->resourceType(),
+            RequestMethod::UPDATE
         );
 
         $query = ResourceQuery::queryOne($resourceType);

--- a/src/Http/Controllers/Actions/UpdateRelationship.php
+++ b/src/Http/Controllers/Actions/UpdateRelationship.php
@@ -17,6 +17,7 @@ use LaravelJsonApi\Contracts\Routing\Route;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
 use LaravelJsonApi\Core\Responses\RelationshipResponse;
 use LaravelJsonApi\Core\Support\Str;
+use LaravelJsonApi\Laravel\Http\Requests\RequestMethod;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceQuery;
 use LaravelJsonApi\Laravel\Http\Requests\ResourceRequest;
 
@@ -37,7 +38,8 @@ trait UpdateRelationship
             ->relationship($fieldName = $route->fieldName());
 
         $request = ResourceRequest::forResource(
-            $resourceType = $route->resourceType()
+            $resourceType = $route->resourceType(),
+            RequestMethod::UPDATE_RELATIONSHIP
         );
 
         $query = $relation->toOne() ?

--- a/src/Http/Requests/RequestMethod.php
+++ b/src/Http/Requests/RequestMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace LaravelJsonApi\Laravel\Http\Requests;
+
+/**
+ * Enum representing different types of request methods.
+ */
+enum RequestMethod: string
+{
+    case ATTACH_RELATIONSHIP = 'AttachRelationship';
+    case DETACH_RELATIONSHIP = 'DetachRelationship';
+    case UPDATE_RELATIONSHIP = 'UpdateRelationship';
+    case STORE = 'Create';
+    case UPDATE = 'Update';
+}

--- a/src/Http/Requests/ResourceRequest.php
+++ b/src/Http/Requests/ResourceRequest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Laravel\Http\Requests;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Database\Eloquent\Model;
@@ -62,13 +63,14 @@ class ResourceRequest extends FormRequest
      * Resolve the request instance for the specified resource type.
      *
      * @param string $resourceType
+     * @param RequestMethod|null $requestMethod
      * @return ResourceRequest
      */
-    public static function forResource(string $resourceType): ResourceRequest
+    public static function forResource(string $resourceType, RequestMethod $requestMethod = null): ResourceRequest
     {
         $resolver = self::$requestResolver ?: new RequestResolver(RequestResolver::REQUEST);
 
-        return $resolver($resourceType);
+        return $resolver($resourceType, false, $requestMethod);
     }
 
     /**


### PR DESCRIPTION
TODO: Add test cases

This PR adds the option to allow users in creating requests by method. 
Example: `CreatePostRequest` and `UpdatePostRequest`