### PR TITLE
feat: support Illuminate\Auth\Access\Response from authorizer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "laravel-json-api/core": "^4.3.2",
+        "laravel-json-api/core": "^4.3.2|^5.0.1",
         "laravel-json-api/eloquent": "^4.4",
         "laravel-json-api/encoder-neomerx": "^4.1",
         "laravel-json-api/exceptions": "^3.1",

--- a/src/Http/Requests/ResourceQuery.php
+++ b/src/Http/Requests/ResourceQuery.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Laravel\Http\Requests;
 
+use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Database\Eloquent\Model;
 use LaravelJsonApi\Contracts\Auth\Authorizer;
@@ -104,9 +105,9 @@ class ResourceQuery extends FormRequest implements QueryParameters
      * Perform resource authorization.
      *
      * @param Authorizer $authorizer
-     * @return bool
+     * @return bool|Response
      */
-    public function authorizeResource(Authorizer $authorizer): bool
+    public function authorizeResource(Authorizer $authorizer): bool|Response
     {
         if ($this->isViewingAny()) {
             return $authorizer->index(

--- a/src/Http/Requests/ResourceRequest.php
+++ b/src/Http/Requests/ResourceRequest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace LaravelJsonApi\Laravel\Http\Requests;
 
+use Illuminate\Auth\Access\Response;
 use Illuminate\Contracts\Validation\Factory as ValidationFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Database\Eloquent\Model;
@@ -150,9 +151,9 @@ class ResourceRequest extends FormRequest
      * Perform resource authorization.
      *
      * @param Authorizer $authorizer
-     * @return bool
+     * @return bool|Response
      */
-    public function authorizeResource(Authorizer $authorizer): bool
+    public function authorizeResource(Authorizer $authorizer): bool|Response
     {
         if ($this->isCreating()) {
             return $authorizer->store(

--- a/tests/dummy/app/Http/Controllers/Api/V1/UserController.php
+++ b/tests/dummy/app/Http/Controllers/Api/V1/UserController.php
@@ -19,6 +19,7 @@ use LaravelJsonApi\Laravel\Http\Controllers\Actions;
 class UserController extends Controller
 {
     use Actions\FetchOne;
+    use Actions\Destroy;
     use Actions\FetchRelated;
     use Actions\FetchRelationship;
     use Actions\UpdateRelationship;

--- a/tests/dummy/app/Policies/UserPolicy.php
+++ b/tests/dummy/app/Policies/UserPolicy.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace App\Policies;
 
 use App\Models\User;
+use Illuminate\Auth\Access\Response;
 
 class UserPolicy
 {
@@ -50,4 +51,17 @@ class UserPolicy
     {
         return $user->is($other);
     }
+
+    /**
+     * Determine if the user can delete the other user.
+     *
+     * @param User $user
+     * @param User $other
+     * @return bool|Response
+     */
+    public function delete(User $user, User $other)
+    {
+        return $user->is($other) ? true : Response::denyAsNotFound('not found message');
+    }
+
 }

--- a/tests/dummy/routes/api.php
+++ b/tests/dummy/routes/api.php
@@ -25,7 +25,7 @@ JsonApiRoute::server('v1')
         });
 
         /** Users */
-        $server->resource('users')->only('show')->relationships(function ($relationships) {
+        $server->resource('users')->only('show','destroy')->relationships(function ($relationships) {
             $relationships->hasOne('phone');
         })->actions(function ($actions) {
             $actions->get('me');

--- a/tests/dummy/tests/Api/V1/Users/DeleteTest.php
+++ b/tests/dummy/tests/Api/V1/Users/DeleteTest.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright 2024 Cloud Creativity Limited
+ *
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+
+declare(strict_types=1);
+
+namespace App\Tests\Api\V1\Users;
+
+use App\Models\User;
+use App\Tests\Api\V1\TestCase;
+
+class DeleteTest extends TestCase
+{
+
+    public function test(): void
+    {
+        $user = User::factory()->createOne();
+
+        $expected = $this->serializer
+            ->user($user);
+        $response = $this
+            ->actingAs(User::factory()->createOne())
+            ->jsonApi('users')
+            ->delete(url('/api/v1/users', $expected['id']));
+
+        $response->assertNotFound()
+            ->assertHasError(404, [
+            'detail' => 'not found message',
+            'status' => '404',
+            'title' => 'Not Found',
+        ]);
+    }
+}


### PR DESCRIPTION
This PR is dependent on https://github.com/laravel-json-api/core/pull/19 and adds support for gates and policies with Illuminate\Auth\Access\Response return values. 

I have not modified the composer.json to pull this branch from core but have tested it with it locally.