### PR TITLE
Fix: remove deprecation notices in PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.2, 8.3]
+        php: [8.2, 8.3, 8.4]
         laravel: [11]
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ## Unreleased
 
+### Fixed
+
+- Remove deprecation notices in PHP 8.4.
+
 ## [4.1.0] - 2024-06-26
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -25,16 +25,16 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "laravel-json-api/core": "^4.1",
-        "laravel-json-api/eloquent": "^4.1",
-        "laravel-json-api/encoder-neomerx": "^4.0",
-        "laravel-json-api/exceptions": "^3.0",
-        "laravel-json-api/spec": "^3.0",
-        "laravel-json-api/validation": "^4.0",
+        "laravel-json-api/core": "^4.3.2",
+        "laravel-json-api/eloquent": "^4.4",
+        "laravel-json-api/encoder-neomerx": "^4.1",
+        "laravel-json-api/exceptions": "^3.1",
+        "laravel-json-api/spec": "^3.1",
+        "laravel-json-api/validation": "^4.2",
         "laravel/framework": "^11.0"
     },
     "require-dev": {
-        "laravel-json-api/testing": "^3.0",
+        "laravel-json-api/testing": "^3.0.2",
         "orchestra/testbench": "^9.0",
         "phpunit/phpunit": "^10.5"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false"
-         beStrictAboutTestsThatDoNotTestAnything="true" bootstrap="vendor/autoload.php" colors="true"
-         processIsolation="false" stopOnError="false" stopOnFailure="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache"
-         backupStaticProperties="false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false"
+         failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+>
     <coverage/>
     <testsuites>
         <testsuite name="Unit">

--- a/src/Exceptions/HttpNotAcceptableException.php
+++ b/src/Exceptions/HttpNotAcceptableException.php
@@ -26,8 +26,8 @@ class HttpNotAcceptableException extends HttpException
      * @param int $code
      */
     public function __construct(
-        string $message = null,
-        Throwable $previous = null,
+        ?string $message = null,
+        ?Throwable $previous = null,
         array $headers = [],
         int $code = 0
     ) {

--- a/src/Routing/ActionRegistrar.php
+++ b/src/Routing/ActionRegistrar.php
@@ -77,7 +77,7 @@ class ActionRegistrar
         string $resourceType,
         array $options,
         string $controller,
-        string $prefix = null
+        ?string $prefix = null
     ) {
         $this->router = $router;
         $this->resource = $resource;
@@ -106,7 +106,7 @@ class ActionRegistrar
      * @param string|null $method
      * @return ActionProxy
      */
-    public function get(string $uri, string $method = null): ActionProxy
+    public function get(string $uri, ?string $method = null): ActionProxy
     {
         return $this->register('get', $uri, $method);
     }
@@ -118,7 +118,7 @@ class ActionRegistrar
      * @param string|null $method
      * @return ActionProxy
      */
-    public function post(string $uri, string $method = null): ActionProxy
+    public function post(string $uri, ?string $method = null): ActionProxy
     {
         return $this->register('post', $uri, $method);
     }
@@ -130,7 +130,7 @@ class ActionRegistrar
      * @param string|null $method
      * @return ActionProxy
      */
-    public function patch(string $uri, string $method = null): ActionProxy
+    public function patch(string $uri, ?string $method = null): ActionProxy
     {
         return $this->register('patch', $uri, $method);
     }
@@ -142,7 +142,7 @@ class ActionRegistrar
      * @param string|null $method
      * @return ActionProxy
      */
-    public function put(string $uri, string $method = null): ActionProxy
+    public function put(string $uri, ?string $method = null): ActionProxy
     {
         return $this->register('put', $uri, $method);
     }
@@ -154,7 +154,7 @@ class ActionRegistrar
      * @param string|null $method
      * @return ActionProxy
      */
-    public function delete(string $uri, string $method = null): ActionProxy
+    public function delete(string $uri, ?string $method = null): ActionProxy
     {
         return $this->register('delete', $uri, $method);
     }
@@ -166,7 +166,7 @@ class ActionRegistrar
      * @param string|null $method
      * @return ActionProxy
      */
-    public function options(string $uri, string $method = null): ActionProxy
+    public function options(string $uri, ?string $method = null): ActionProxy
     {
         return $this->register('options', $uri, $method);
     }
@@ -177,7 +177,7 @@ class ActionRegistrar
      * @param string|null $action
      * @return ActionProxy
      */
-    public function register(string $method, string $uri, string $action = null): ActionProxy
+    public function register(string $method, string $uri, ?string $action = null): ActionProxy
     {
         $action = $action ?: $this->guessControllerAction($uri);
         $parameter = $this->getParameter();

--- a/src/Routing/PendingResourceRegistration.php
+++ b/src/Routing/PendingResourceRegistration.php
@@ -229,7 +229,7 @@ class PendingResourceRegistration
      * @param Closure|null $callback
      * @return $this
      */
-    public function actions($prefixOrCallback, Closure $callback = null): self
+    public function actions($prefixOrCallback, ?Closure $callback = null): self
     {
         if ($prefixOrCallback instanceof Closure && null === $callback) {
             $this->actionsPrefix = null;

--- a/src/Routing/ResourceRegistrar.php
+++ b/src/Routing/ResourceRegistrar.php
@@ -51,7 +51,7 @@ class ResourceRegistrar
      * @param string|null $controller
      * @return PendingResourceRegistration
      */
-    public function resource(string $resourceType, string $controller = null): PendingResourceRegistration
+    public function resource(string $resourceType, ?string $controller = null): PendingResourceRegistration
     {
         return new PendingResourceRegistration(
             $this,

--- a/tests/lib/Integration/Routing/TestCase.php
+++ b/tests/lib/Integration/Routing/TestCase.php
@@ -66,8 +66,8 @@ class TestCase extends BaseTestCase
     protected function createSchema(
         Server $server,
         string $name,
-        string $pattern = null,
-        string $uriType = null
+        ?string $pattern = null,
+        ?string $uriType = null
     ): Schema
     {
         $schema = $this->createMock(Schema::class);
@@ -89,7 +89,7 @@ class TestCase extends BaseTestCase
      * @param string|null $uriName
      * @return void
      */
-    protected function createRelation(MockObject $schema, string $fieldName, string $uriName = null): void
+    protected function createRelation(MockObject $schema, string $fieldName, ?string $uriName = null): void
     {
         $relation = $this->createMock(Relation::class);
         $relation->method('name')->willReturn($fieldName);


### PR DESCRIPTION
Improve support for PHP 8.4 by removing deprecation notices.