### PR TITLE
Update the schema stub to use iterable for the fields and filters

### DIFF
--- a/stubs/schema.stub
+++ b/stubs/schema.stub
@@ -24,9 +24,9 @@ class {{ class }} extends {{ schema }}
     /**
      * Get the resource fields.
      *
-     * @return iterable
+     * @return array<mixed>
      */
-    public function fields(): iterable
+    public function fields(): array
     {
         return [
             ID::make(),
@@ -38,9 +38,9 @@ class {{ class }} extends {{ schema }}
     /**
      * Get the resource filters.
      *
-     * @return iterable<Filter>
+     * @return array<Filter>
      */
-    public function filters(): iterable
+    public function filters(): array
     {
         return [
             WhereIdIn::make($this),


### PR DESCRIPTION
In the [core/src/Core/Schema/Schema.php](https://github.com/laravel-json-api/core/blob/develop/src/Core/Schema/Schema.php) both `fields` and `filters` returns iterable, but stubs still generate them as arrays:

[`abstract public function fields(): iterable;`](https://github.com/laravel-json-api/core/blob/develop/src/Core/Schema/Schema.php#L108)

[`public function filters(): iterable`](https://github.com/laravel-json-api/core/blob/develop/src/Core/Schema/Schema.php#L396)